### PR TITLE
fix(frontend/backend): Filter featured mods based on minecraft version

### DIFF
--- a/src-tauri/src/app/modrinth_api.rs
+++ b/src-tauri/src/app/modrinth_api.rs
@@ -1,6 +1,6 @@
+use std::error::Error;
 #[cfg(target_os = "linux")]
 use std::fs::metadata;
-use std::error::Error;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -132,6 +132,7 @@ pub struct ModInfo {
     pub title: String,
     pub description: String,
     pub icon_url: String,
+    pub game_versions: Option<Vec<String>>,
 }
 
 //Minified response from https://api.modrinth.com/v2/project/{id|slug}

--- a/src/components/modrinth/ModrinthScreen.svelte
+++ b/src/components/modrinth/ModrinthScreen.svelte
@@ -153,6 +153,7 @@
             // Fetch featured mods
             await invoke("get_featured_mods", {
                 branch: currentBranch,
+                mcVersion: launchManifest.build.mcVersion,
             }).then((result) => {
                 console.debug("Featured Mods", result);
                 mods = result;


### PR DESCRIPTION
Fixes https://github.com/NoRiskClient/issues/issues/96