### PR TITLE
fix(settings): toggles having different style than sliders

### DIFF
--- a/src/components/config/inputs/ConfigRadioButton.svelte
+++ b/src/components/config/inputs/ConfigRadioButton.svelte
@@ -86,7 +86,7 @@
         left: 2px;
         bottom: 2px;
         background-color: #ffffff;
-        border-radius: 50%;
+        border-radius: 5px;
         box-shadow: 0px 2px 5px var(--font-color-text-shadow);
         -webkit-transition: .4s;
         transition: .4s;


### PR DESCRIPTION
`.nes-slider:before` had a border radius of 50% wich looked weird, since it was different from the sliders.

The toggle and slider handles now have the same border radius of 5px
