### PR TITLE
Restore LiquidLauncher attribution to README for GPL compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 If you notice any bugs or missing features, you can let us know by opening an issue [here](https://github.com/NoRiskClient/issues/issues/new/choose).
 
 ## License
+This code is originally forked from [LiquidLauncher](https://github.com/CCBlueX/LiquidLauncher).
+
+Therefore, this project is also subject to the [GNU General Public License v3.0](LICENSE). This does only apply for source code located directly in this clean repository. During the development and compilation process, additional source code may be used to which we have obtained no rights. Such code is not covered by the GPL license.
+
 this project entirely or partially for free and even commercially. However, please consider the following:
 
 - **You must disclose the source code of your modified work and the source code you took from this project. This means you are not allowed to use code from this project (even partially) in a closed-source (or even obfuscated) application.**


### PR DESCRIPTION
This pull request restores the original attribution to [LiquidLauncher](https://github.com/CCBlueX/LiquidLauncher) in the README file, which was removed in commit 3605c06. Since this project is a fork of LiquidLauncher and uses the GPLv3 license, proper attribution is both ethically expected and legally required under the terms of the license.

This change simply reinstates the original wording that acknowledged the project's origins. Maintaining this attribution helps uphold open source standards and respects the contributions of the upstream developers.

Let me know if any additional clarification is needed.