### PR TITLE
Fix connection-hijacking vulnerability

### DIFF
--- a/src-tauri/src/minecraft/api/norisk_api.rs
+++ b/src-tauri/src/minecraft/api/norisk_api.rs
@@ -81,7 +81,16 @@ impl NoRiskApi {
         debug!("[NoRisk API] Parsing server ID response as JSON");
         match response.json::<ServerIdResponse>().await {
             Ok(server_response) => {
-                info!("[NoRisk API] Server ID request successful: {}", server_response.server_id);
+                let server_id = &server_response.server_id;
+                if !server_id.starts_with("nrc-") {
+                    error!("[NoRisk API] Invalid server ID received: {}", server_id);
+                    return Err(AppError::RequestError(format!(
+                        "Invalid server ID received from NoRisk API: {}",
+                        server_id
+                    )));
+                }
+                
+                info!("[NoRisk API] Server ID request successful: {}", server_id);
                 Ok(server_response)
             }
             Err(e) => {


### PR DESCRIPTION
Added check for server-id Format to enforce the custom Format on the client-side, preventing the Backend from potentially requesting the Authentication of a server-id being used in the Connection to a Minecraft Server (which are always BigInts), therefore preventing possible Connection hijacking originating from the backend (which is unlikely to happen, but would still be possible)