### PR TITLE
Cape 3D preview

### DIFF
--- a/src/components/capes/CapeList.tsx
+++ b/src/components/capes/CapeList.tsx
@@ -21,6 +21,7 @@ import { Modal } from "../ui/Modal";
 import { SkinView3DWrapper } from "../common/SkinView3DWrapper";
 import { useMinecraftAuthStore } from "../../store/minecraft-auth-store";
 import gsap from "gsap";
+import { IconButton } from "../ui/buttons/IconButton";
 
 
 const ListComponent = React.forwardRef<
@@ -552,16 +553,43 @@ export function CapeList({
           width="lg"
           variant="flat"
         >
-          <div style={{ width: 340, height: 420, margin: "0 auto" }}>
-            <SkinView3DWrapper
-              skinUrl={userSkinUrl}
-              capeUrl={`https://cdn.norisk.gg/capes-staging/prod/${show3DPreview.cape._id}.png`}
-              enableAutoRotate={true}
-              zoom={1.5}
-            />
-          </div>
+          <Cape3DPreviewWithToggle
+            skinUrl={userSkinUrl}
+            capeId={show3DPreview.cape._id}
+          />
         </Modal>
       )}
+    </div>
+  );
+}
+
+function Cape3DPreviewWithToggle({ skinUrl, capeId }: { skinUrl?: string; capeId: string }) {
+  const [showElytra, setShowElytra] = useState(false);
+  return (
+    <div style={{ width: 340, height: 420, margin: "0 auto", position: "relative" }}>
+      <IconButton
+        onClick={() => setShowElytra((v) => !v)}
+        variant="ghost"
+        size="sm"
+        className="absolute top-2 right-2 z-10"
+        icon={
+          <Icon
+            icon={showElytra ? "ph:airplane-tilt-fill" : "ph:airplane-tilt-duotone"}
+            className="w-5 h-5"
+          />
+        }
+        title={showElytra ? "Show as Cape" : "Show as Elytra"}
+        aria-label={showElytra ? "Show as Cape" : "Show as Elytra"}
+      />
+      <SkinView3DWrapper
+        skinUrl={skinUrl}
+        capeUrl={`https://cdn.norisk.gg/capes-staging/prod/${capeId}.png`}
+        enableAutoRotate={true}
+        zoom={1.5}
+        displayAsElytra={showElytra}
+        width={340}
+        height={420}
+      />
     </div>
   );
 }

--- a/src/components/capes/CapeList.tsx
+++ b/src/components/capes/CapeList.tsx
@@ -525,8 +525,6 @@ export function CapeList({
             backdropFilter: "blur(8px)",
             WebkitBackdropFilter: "blur(8px)",
             boxShadow: "0 8px 16px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.05)",
-            minWidth: 200,
-            padding: 0,
           }}
           onClick={e => e.stopPropagation()}
         >
@@ -536,12 +534,13 @@ export function CapeList({
           />
           <ul className="py-1">
             <li
-              className="px-4 py-2.5 flex items-center gap-3 hover:bg-white/10 cursor-pointer transition-colors duration-150 text-white font-minecraft text-lg"
+              className="px-4 py-2.5 flex items-center gap-3 hover:bg-white/10 cursor-pointer transition-colors duration-150"
               onClick={handlePreview3D}
-              style={{ minWidth: 180 }}
             >
-              <Icon icon="ph:eye-bold" className="w-5 h-5 opacity-80" />
-              Preview
+              <Icon icon="ph:eye-bold" className="w-5 h-5 text-white" />
+              <span className="font-minecraft-ten text-base text-white/80">
+                Preview
+              </span>
             </li>
           </ul>
         </div>
@@ -566,7 +565,7 @@ export function CapeList({
 function Cape3DPreviewWithToggle({ skinUrl, capeId }: { skinUrl?: string; capeId: string }) {
   const [showElytra, setShowElytra] = useState(false);
   return (
-    <div style={{ width: 340, height: 420, margin: "0 auto", position: "relative" }}>
+    <div style={{ width: 300, height: 380, margin: "0 auto", position: "relative" }}>
       <IconButton
         onClick={() => setShowElytra((v) => !v)}
         variant="ghost"
@@ -585,10 +584,12 @@ function Cape3DPreviewWithToggle({ skinUrl, capeId }: { skinUrl?: string; capeId
         skinUrl={skinUrl}
         capeUrl={`https://cdn.norisk.gg/capes-staging/prod/${capeId}.png`}
         enableAutoRotate={true}
-        zoom={1.5}
+        autoRotateSpeed={0.5}
+        startFromBack={true}
+        zoom={0.9}
         displayAsElytra={showElytra}
-        width={340}
-        height={420}
+        width={300}
+        height={380}
       />
     </div>
   );

--- a/src/components/common/SkinView3DWrapper.tsx
+++ b/src/components/common/SkinView3DWrapper.tsx
@@ -13,10 +13,11 @@ interface SkinView3DWrapperProps {
   enableAutoRotate?: boolean;
   zoom?: number;
   displayAsElytra?: boolean;
+  onPaintPixel?: (x: any, y: any) => void;
 }
 
-// A known public URL for a "Steve" skin, can be used as a default
-const DEFAULT_STEVE_SKIN_URL = 'https://api.mineatar.com/skin/Steve'; // A common Steve skin URL
+
+const DEFAULT_STEVE_SKIN_URL = 'https://api.mineatar.com/skin/Steve'; 
 
 export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
   skinUrl,
@@ -25,7 +26,7 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
   width: propWidth,
   height: propHeight,
   enableAutoRotate = false,
-  zoom = 1.0, // Default zoom
+  zoom = 1.0,
   displayAsElytra = false,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -51,9 +52,9 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
     }
     viewer.autoRotate = enableAutoRotate;
     viewer.zoom = zoom;
-    // Rotate the player slightly for a better initial view if not auto-rotating
+   
     if (!enableAutoRotate && viewer.playerObject) {
-        viewer.playerObject.rotation.y = Math.PI; // CHANGED to show back
+        viewer.playerObject.rotation.y = Math.PI; 
     }
 
 
@@ -73,55 +74,41 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
     return () => {
       resizeObserver.disconnect();
       if (skinViewerRef.current) {
-        // skinview3d documentation doesn't explicitly show a general dispose method
-        // on the SkinViewer instance. It's assumed that when the canvas is removed
-        // and references are dropped, resources are garbage collected.
-        // If there were specific methods like skinViewer.destroy() or .dispose(),
-        // they would be called here.
+      
         skinViewerRef.current = null;
       }
     };
-  // skinUrl dependency is removed from here, handled by its own useEffect
-  // capeUrl dependency is removed from here, handled by its own useEffect
-  // displayAsElytra dependency is removed from here, handled by its own useEffect
-  }, [propWidth, propHeight, enableAutoRotate, zoom]); // REVERTED: displayAsElytra removed from this dependency array
 
-  // Effect for skinUrl changes
+  }, [propWidth, propHeight, enableAutoRotate, zoom]);
+
+ 
   useEffect(() => {
     if (skinViewerRef.current) {
       if (skinUrl === null) {
-        // Load a default or transparent skin if null is meant to hide the current one
-        // For now, we load the default Steve skin if skinUrl becomes null explicitly.
-        // Or, if `loadSkin(null)` is supported to clear, that would be used.
-        // The constructor handles undefined/default, this is for dynamic changes.
+        
         skinViewerRef.current.loadSkin(DEFAULT_STEVE_SKIN_URL);
       } else if (skinUrl) {
         skinViewerRef.current.loadSkin(skinUrl);
       }
-      // If skinUrl is undefined, it means use the initial/default, so no change here.
     }
   }, [skinUrl]);
 
-  // Effect for capeUrl changes
   useEffect(() => {
     if (skinViewerRef.current) {
       if (capeUrl === null) {
-        skinViewerRef.current.loadCape(null); // Unload cape
+        skinViewerRef.current.loadCape(null);
       } else if (capeUrl) {
         skinViewerRef.current.loadCape(capeUrl, displayAsElytra ? { backEquipment: "elytra" } : undefined);
       }
-      // If capeUrl is undefined, do nothing (keep existing cape or no cape)
     }
-  }, [capeUrl, displayAsElytra]); // ADDED displayAsElytra dependency
+  }, [capeUrl, displayAsElytra]);
 
-  // Effect for autoRotate changes
   useEffect(() => {
     if (skinViewerRef.current) {
       skinViewerRef.current.autoRotate = enableAutoRotate;
     }
   }, [enableAutoRotate]);
 
-  // Effect for zoom changes
   useEffect(() => {
     if (skinViewerRef.current) {
       skinViewerRef.current.zoom = zoom;
@@ -130,7 +117,7 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
 
   return (
     <div ref={containerRef} className={cn("w-full h-full", className)}>
-      <canvas ref={canvasRef} style={{ display: 'block' }} /> {/* Ensure canvas is block to fill div */}
+      <canvas ref={canvasRef} style={{ display: 'block' }} />
     </div>
   );
 }; 

--- a/src/components/common/SkinView3DWrapper.tsx
+++ b/src/components/common/SkinView3DWrapper.tsx
@@ -14,6 +14,8 @@ interface SkinView3DWrapperProps {
   zoom?: number;
   displayAsElytra?: boolean;
   onPaintPixel?: (x: any, y: any) => void;
+  autoRotateSpeed?: number;
+  startFromBack?: boolean;
 }
 
 
@@ -28,6 +30,8 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
   enableAutoRotate = false,
   zoom = 1.0,
   displayAsElytra = false,
+  autoRotateSpeed = 1.0,
+  startFromBack = false,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const skinViewerRef = useRef<skinview3d.SkinViewer | null>(null);
@@ -51,9 +55,14 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
       viewer.loadCape(capeUrl, displayAsElytra ? { backEquipment: "elytra" } : undefined);
     }
     viewer.autoRotate = enableAutoRotate;
+    if (enableAutoRotate && autoRotateSpeed !== 1.0) {
+      viewer.autoRotateSpeed = autoRotateSpeed;
+    }
     viewer.zoom = zoom;
    
-    if (!enableAutoRotate && viewer.playerObject) {
+    if (startFromBack && viewer.playerObject) {
+        viewer.playerObject.rotation.y = Math.PI; 
+    } else if (!enableAutoRotate && viewer.playerObject) {
         viewer.playerObject.rotation.y = Math.PI; 
     }
 


### PR DESCRIPTION
Ich habe dem Cape-Shop eine neue Funktion hinzugefügt, die es Nutzern ermöglicht per Rechtsklick eine 3D-Vorschau zu öffnen. Dadurch kann das Cape direkt am eigenen Skin angschaut werden, ganz ohne das Spiel starten zu müssen.

Hinweise: Capes, bei denen "ERROR" angezeigt wird (einschließlich eigener Capes), können derzeit nicht in der Vorschau angezeigt werden.




https://github.com/user-attachments/assets/f16d14d3-ed4b-4bee-9784-ac3c73c6ebd8



**Getestet auf Windows 11**
**Achtung: Unter Linux funktioniert der Blur-Effekt derzeit nicht wie geplant, da es dort systembedingt Einschränkungen gibt!**
Feedback ist gerne gesehen!