### PR TITLE
Don't allow folder names that cause a java error

### DIFF
--- a/src-tauri/src/utils/path_utils.rs
+++ b/src-tauri/src/utils/path_utils.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 /// Findet einen eindeutigen Verzeichnisnamen (Segment) in einem Basisverzeichnis.
 /// Wenn "desired_segment" schon existiert, werden Suffixe wie "(1)", "(2)" usw. angehängt.
+/// Stellt zusätzlich sicher, dass keine problematischen Character enthalten sind.
 /// Gibt den eindeutigen Segmentnamen als String zurück.
 pub async fn find_unique_profile_segment(
     base_profiles_dir: &Path,
@@ -22,8 +23,14 @@ pub async fn find_unique_profile_segment(
         base_profiles_dir.display()
     );
 
+    // Problematische Character durch '_' ersetzen
+    let sanitized_segment = desired_segment.replace(
+        ['/', '\\', '?', '!', '<', '>', '*', ':', '\'', '\"', '|'],
+        "_",
+    );
+
     // Bereinigen und sicherstellen, dass der Segmentname nicht leer ist
-    let clean_segment = desired_segment.trim();
+    let clean_segment = sanitized_segment.trim();
     if clean_segment.is_empty() {
         error!("Desired segment name cannot be empty.");
         // Erwäge, hier einen Standardnamen oder einen eindeutigen Zeitstempel zu generieren


### PR DESCRIPTION
Aufgrund dieser Nachricht:
"Ich will All Simple Voicechat Modpack für nen Sever nutzen aber es stürzt die ganze Zeit ab mit Exitcode 1"
stellte sich heraus, dass Java nicht mit z.B. Ausrufezeichen in Ordnernamen zurechtkommt (hier "All Simple Voice Chat Connections!").
Dieses PR ersetzt dieses und noch weitere Zeichen durch "_" um so etwas in Zukunft zu vermeiden.