### PR TITLE
feat: add font customization options in SettingsTab

### DIFF
--- a/src/components/launcher/MainLaunchButton.tsx
+++ b/src/components/launcher/MainLaunchButton.tsx
@@ -387,8 +387,10 @@ export function MainLaunchButton({
 
     const displaySubText = statusSubText || selectedVersionLabel;
     return (
-      <div className="w-full flex flex-col items-center justify-center leading-none -mt-4">
-        <span className="text-5xl text-center lowercase">{actionText}</span>{" "}
+      <div className="launch-btn w-full flex flex-col items-center justify-center leading-none -mt-4">
+        <span className="font-minecraft text-5xl text-center lowercase">
+          {actionText}
+        </span>{" "}
         {displaySubText && (
           <span
             className={cn(

--- a/src/components/modrinth/v2/ModrinthSearchControlsV2.tsx
+++ b/src/components/modrinth/v2/ModrinthSearchControlsV2.tsx
@@ -115,7 +115,7 @@ export const ModrinthSearchControlsV2: React.FC<
               onClick={() => onProjectTypeChange(type)}
               variant={projectType === type ? "flat" : "ghost"}
               size={buttonSize}
-              className={`flex-1 min-w-0 text-[1.7em]`}
+              className={`flex-1 min-w-0 text-2xl`}
             >
               {type}s
             </Button>

--- a/src/components/tabs/SettingsTab.tsx
+++ b/src/components/tabs/SettingsTab.tsx
@@ -61,6 +61,12 @@ export function SettingsTab() {
   } = useThemeStore();
   const { currentEffect, setCurrentEffect } = useBackgroundEffectStore();
   const { qualityLevel, setQualityLevel } = useQualitySettingsStore();
+  const {
+    headerFontPreset,
+    textFontPreset,
+    setHeaderFontPreset,
+    setTextFontPreset,
+  } = useThemeStore();
 
   const { confirm, confirmDialog } = useConfirmDialog();
 
@@ -478,16 +484,143 @@ export function SettingsTab() {
               size="md"
             >
               Download
-            </Button>          </div>
+            </Button>          
+          </div>
         </div>
+      </Card>
+
+      <Card variant="flat" className="p-6">
+        <div className="mb-4">
+          <div className="flex items-center gap-2 mb-2">
+            <Icon icon="solar:text-bold" className="w-6 h-6 text-white" />
+            <h3 className="text-3xl font-minecraft text-white lowercase">
+              Typography
+            </h3>
+          </div>
+          <p className="text-base text-white/70 font-minecraft-ten mt-2">
+            Choose fonts and base size used throughout the launcher
+          </p>
+        </div>
+
+        {(() => {
+          const options = [
+            {
+              value: "minecraft" as const,
+              label: "Minecraft (default)",
+              headerSample: 'Minecraft, monospace',
+              textSample:
+                'MinecraftTen, ui-sans-serif, system-ui, "Segoe UI", Inter, sans-serif',
+            },
+            {
+              value: "system" as const,
+              label: "System Sans",
+              headerSample:
+                'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Inter, "Noto Sans", Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif',
+              textSample:
+                'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Inter, "Noto Sans", Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif',
+            },
+            {
+              value: "monospace" as const,
+              label: "Monospace",
+              headerSample:
+                'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", "Cascadia Mono", "Fira Code", "Courier New", monospace',
+              textSample:
+                'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", "Cascadia Mono", "Fira Code", "Courier New", monospace',
+            },
+          ];
+
+          return (
+            <div className="space-y-6">
+              <div>
+                <h4 className="text-xl font-minecraft text-white lowercase mb-3">Header font</h4>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  {options.map((opt) => (
+                    <Card
+                      key={`header-${opt.value}`}
+                      variant="flat"
+                      className={cn(
+                        "relative cursor-pointer transition-all duration-300 p-4",
+                        headerFontPreset === opt.value
+                          ? "ring-2 ring-white/30"
+                          : "hover:bg-black/40",
+                      )}
+                      onClick={() => setHeaderFontPreset(opt.value)}
+                    >
+                      <div className="flex flex-col gap-2">
+                        <h5 className="text-xl text-white font-minecraft-ten lowercase">{opt.label}</h5>
+                        <div className="rounded-md p-3 bg-black/40 border border-white/10">
+                          <div
+                            className="text-white text-base mb-1"
+                            style={{ fontFamily: opt.headerSample as string }}
+                          >
+                            Heading Sample
+                          </div>
+                        </div>
+                      </div>
+                      {headerFontPreset === opt.value && (
+                        <div className="absolute top-2 right-2">
+                          <Icon
+                            icon="solar:check-circle-bold"
+                            className="w-5 h-5"
+                            style={{ color: accentColor.value }}
+                          />
+                        </div>
+                      )}
+                    </Card>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h4 className="text-xl font-minecraft text-white lowercase mb-3">Text font</h4>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  {options.map((opt) => (
+                    <Card
+                      key={`text-${opt.value}`}
+                      variant="flat"
+                      className={cn(
+                        "relative cursor-pointer transition-all duration-300 p-4",
+                        textFontPreset === opt.value
+                          ? "ring-2 ring-white/30"
+                          : "hover:bg-black/40",
+                      )}
+                      onClick={() => setTextFontPreset(opt.value)}
+                    >
+                      <div className="flex flex-col gap-2">
+                        <h5 className="text-xl text-white font-minecraft-ten lowercase">{opt.label}</h5>
+                        <div className="rounded-md p-3 bg-black/40 border border-white/10">
+                          <div
+                            className="text-white/80 text-xs"
+                            style={{ fontFamily: opt.textSample as string }}
+                          >
+                            Lorem ipsum dolor sit amet
+                          </div>
+                        </div>
+                      </div>
+                      {textFontPreset === opt.value && (
+                        <div className="absolute top-2 right-2">
+                          <Icon
+                            icon="solar:check-circle-bold"
+                            className="w-5 h-5"
+                            style={{ color: accentColor.value }}
+                          />
+                        </div>
+                      )}
+                    </Card>
+                  ))}
+                </div>
+              </div>
+            </div>
+          );
+        })()}
       </Card>
 
       <Card variant="flat" className="p-6">
           <div className="flex items-center gap-2 mb-4">
             <Icon icon="solar:palette-bold" className="w-5 h-5 text-white" />
-            <h4 className="text-2xl font-minecraft text-white lowercase">
+            <h3 className="text-3xl font-minecraft text-white lowercase">
               Custom Colors
-            </h4>
+            </h3>
           </div>
           <p className="text-sm text-white/70 font-minecraft-ten mb-4">
             Create your own custom accent color
@@ -536,8 +669,11 @@ export function SettingsTab() {
                     />
                   ))}
                 </div>
-              </div>            )}          </div>
-        </Card>      <Card variant="flat" className="p-6">
+              </div>            
+            )}          
+          </div>
+        </Card>      
+        <Card variant="flat" className="p-6">
         <div className="mb-4">
           <div className="flex items-center gap-2 mb-2">
             <Icon icon="solar:widget-bold" className="w-6 h-6 text-white" />

--- a/src/components/tabs/SettingsTab.tsx
+++ b/src/components/tabs/SettingsTab.tsx
@@ -547,11 +547,11 @@ export function SettingsTab() {
                       onClick={() => setHeaderFontPreset(opt.value)}
                     >
                       <div className="flex flex-col gap-2">
-                        <h5 className="text-xl text-white font-minecraft-ten lowercase">{opt.label}</h5>
+                        <p className="text-xl text-white lowercase" style={{ fontFamily: opt.textSample }}>{opt.label}</p>
                         <div className="rounded-md p-3 bg-black/40 border border-white/10">
                           <div
                             className="text-white text-base mb-1"
-                            style={{ fontFamily: opt.headerSample as string }}
+                            style={{ fontFamily: opt.headerSample }}
                           >
                             Heading Sample
                           </div>
@@ -587,11 +587,11 @@ export function SettingsTab() {
                       onClick={() => setTextFontPreset(opt.value)}
                     >
                       <div className="flex flex-col gap-2">
-                        <h5 className="text-xl text-white font-minecraft-ten lowercase">{opt.label}</h5>
+                        <p className="text-xl text-white lowercase" style={{ fontFamily: opt.textSample }}>{opt.label}</p>
                         <div className="rounded-md p-3 bg-black/40 border border-white/10">
                           <div
                             className="text-white/80 text-xs"
-                            style={{ fontFamily: opt.textSample as string }}
+                            style={{ fontFamily: opt.textSample }}
                           >
                             Lorem ipsum dolor sit amet
                           </div>

--- a/src/store/useThemeStore.ts
+++ b/src/store/useThemeStore.ts
@@ -289,6 +289,8 @@ export const useThemeStore = create<ThemeState>()(
         const textFont = getFont(textFontPreset, 'text');
         document.documentElement.style.setProperty('--font-minecraft', headerFont);
         document.documentElement.style.setProperty('--font-minecraft-ten', textFont);
+        // Expose current header font preset
+        document.documentElement.setAttribute('data-header-font', headerFontPreset);
       },
 
       setCustomAccentColor: (hexColor: string) => {

--- a/src/store/useThemeStore.ts
+++ b/src/store/useThemeStore.ts
@@ -207,6 +207,11 @@ interface ThemeState {
   setAccentColor: (color: AccentColor) => void;
   setCustomAccentColor: (hexColor: string) => void;
   applyAccentColorToDOM: () => void;
+  headerFontPreset: FontPreset;
+  textFontPreset: FontPreset;
+  setHeaderFontPreset: (preset: FontPreset) => void;
+  setTextFontPreset: (preset: FontPreset) => void;
+  applyFontPresetsToDOM: () => void;
   customColorHistory: string[];
   addToCustomColorHistory: (hexColor: string) => void;
   clearCustomColorHistory: () => void;
@@ -232,6 +237,8 @@ export const useThemeStore = create<ThemeState>()(
   persist(
     (set, get) => ({
       accentColor: ACCENT_COLORS.blue,
+      headerFontPreset: 'minecraft',
+      textFontPreset: 'minecraft',
       isBackgroundAnimationEnabled: false,
       isDetailViewSidebarOnLeft: true,
       profileGroupingCriterion: "group",
@@ -250,6 +257,38 @@ export const useThemeStore = create<ThemeState>()(
         const clampedRadius = Math.max(MIN_BORDER_RADIUS, Math.min(MAX_BORDER_RADIUS, radius));
         set({ borderRadius: clampedRadius });
         get().applyBorderRadiusToDOM();
+      },
+
+      setHeaderFontPreset: (preset: FontPreset) => {
+        set({ headerFontPreset: preset });
+        get().applyFontPresetsToDOM();
+      },
+
+      setTextFontPreset: (preset: FontPreset) => {
+        set({ textFontPreset: preset });
+        get().applyFontPresetsToDOM();
+      },
+
+      applyFontPresetsToDOM: () => {
+        const { headerFontPreset, textFontPreset } = get();
+        const getFont = (preset: FontPreset, target: 'header' | 'text') => {
+          switch (preset) {
+            case 'minecraft':
+              return target === 'header'
+                ? '"Minecraft", monospace'
+                : '"MinecraftTen", sans-serif';
+            case 'system':
+              return 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Inter, "Noto Sans", Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif';
+            case 'monospace':
+              return 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", "Cascadia Mono", "Fira Code", "Courier New", monospace';
+            default:
+              return '"Minecraft", monospace';
+          }
+        };
+        const headerFont = getFont(headerFontPreset, 'header');
+        const textFont = getFont(textFontPreset, 'text');
+        document.documentElement.style.setProperty('--font-minecraft', headerFont);
+        document.documentElement.style.setProperty('--font-minecraft-ten', textFont);
       },
 
       setCustomAccentColor: (hexColor: string) => {
@@ -385,6 +424,7 @@ export const useThemeStore = create<ThemeState>()(
           
           state.applyAccentColorToDOM();
           state.applyBorderRadiusToDOM();
+          state.applyFontPresetsToDOM?.();
           // Ensure collapsedProfileGroups exists after rehydrate
           if (!Array.isArray(state.collapsedProfileGroups)) {
             state.collapsedProfileGroups = [];
@@ -394,3 +434,6 @@ export const useThemeStore = create<ThemeState>()(
     },
   ),
 );
+
+// Font presets for appearance settings
+export type FontPreset = 'minecraft' | 'system' | 'monospace';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -272,6 +272,11 @@
 :root[data-header-font='monospace'] .text-xl.font-minecraft {
     font-size: 0.9rem;
 }
+:root[data-header-font='system'] .launch-btn,
+:root[data-header-font='monospace'] .launch-btn {
+    /* Reset margin for launch buttons for non Minecraft presets */
+    margin-top: 0;
+}
 
 .text-shadow {
     text-shadow: 0 2px 6px rgba(0, 0, 0, 0.9), 0 0 3px rgba(0, 0, 0, 1);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -247,6 +247,32 @@
     letter-spacing: 0.03em;
 }
 
+/* Normalize heading visual size for non-Minecraft presets */
+:root[data-header-font='system'] .text-6xl.font-minecraft,
+:root[data-header-font='monospace'] .text-6xl.font-minecraft {
+    font-size: 2.5rem;
+}
+:root[data-header-font='system'] .text-5xl.font-minecraft,
+:root[data-header-font='monospace'] .text-5xl.font-minecraft {
+    font-size: 2rem;
+}
+:root[data-header-font='system'] .text-4xl.font-minecraft,
+:root[data-header-font='monospace'] .text-4xl.font-minecraft {
+    font-size: 1.7rem;
+}
+:root[data-header-font='system'] .text-3xl.font-minecraft,
+:root[data-header-font='monospace'] .text-3xl.font-minecraft {
+    font-size: 1.2rem;
+}
+:root[data-header-font='system'] .text-2xl.font-minecraft,
+:root[data-header-font='monospace'] .text-2xl.font-minecraft {
+    font-size: 1.1rem;
+}
+:root[data-header-font='system'] .text-xl.font-minecraft,
+:root[data-header-font='monospace'] .text-xl.font-minecraft {
+    font-size: 0.9rem;
+}
+
 .text-shadow {
     text-shadow: 0 2px 6px rgba(0, 0, 0, 0.9), 0 0 3px rgba(0, 0, 0, 1);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -206,7 +206,7 @@
         background-size: cover;
         background-position: center;
         background-attachment: fixed;
-        font-family: var(--font-minecraft), monospace;
+        font-family: var(--font-minecraft-ten), sans-serif;
         letter-spacing: 0.03em;
     }
 


### PR DESCRIPTION
## What changed
- Added headerFontPreset, textFontPreset, and fontSize to theme store with apply methods
- Added “Typography” section in Appearance settings with separate Header font and Text font selectors
- Applied fonts via CSS variables: --font-minecraft (headers) and --font-minecraft-ten (text)
- Persisted and re-applied on rehydrate via norisk-theme-storage

## Why
- Accessibility
- Personal Pref.

## Testing
- Verified header and text fonts update live via Appearance settings
- Verified base font size updates body text and persists across relaunch
- Confirmed headings use header preset; body and UI text use text preset
- Verified font rendering in MacOS and Windows

<img width="1285" height="808" alt="image" src="https://github.com/user-attachments/assets/59a4036f-1b12-41a7-a72d-752a1096f495" />
<img width="1272" height="800" alt="image" src="https://github.com/user-attachments/assets/e7db7b10-5659-4b62-88a3-5395b4909cfd" />
<img width="1275" height="805" alt="image" src="https://github.com/user-attachments/assets/4610d9c5-fe37-411d-8c79-b3d7e8f8a1f6" />
<img width="1265" height="797" alt="image" src="https://github.com/user-attachments/assets/69b9a311-a576-474b-8dd2-45b65b88e469" />
<img width="1273" height="792" alt="image" src="https://github.com/user-attachments/assets/5b92840d-b017-4ec3-b0b9-5a7b25d21537" />
<img width="1274" height="798" alt="image" src="https://github.com/user-attachments/assets/262d740f-d54a-4817-b2db-b3c9954dee54" />
<img width="1267" height="798" alt="image" src="https://github.com/user-attachments/assets/f191356b-f1cc-426c-b254-66b343d0f8a8" />
