### PR TITLE
fix: crashing on linux in specific cases https://github.com/NoRiskClient/noriskclient-launcher/issues/109

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -119,6 +119,11 @@ async fn main() {
 
     info!("Starting NoRiskClient Launcher...");
 
+    #[cfg(target_os = "linux")]
+    unsafe {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_fs::init())


### PR DESCRIPTION
Fixed an issue with tauri that occurs on Linux in specific cases. My setup (where this occurred):

**OS:** Arch
**WM:** Hyprland (Wayland)
**GPU:** NVidia GeForce RTX 4070
**Drivers:** NVidia 580.82.09 (latest)

User in referenced issue has a similar setup.
#109 

Proof of work:
https://i.imgur.com/AvWGhIT.mp4