### PR TITLE
fix(colorpicker): Color picker gradient does not correctly align with actual color picked

### DIFF
--- a/src/components/modals/ColorPickerModal.tsx
+++ b/src/components/modals/ColorPickerModal.tsx
@@ -194,7 +194,9 @@ export function ColorPickerModal({ onClose, onColorSelected }: ColorPickerModalP
               <div
                 className="absolute inset-0 rounded-lg"
                 style={{
-                  background: 'linear-gradient(to right, white, transparent), linear-gradient(to top, black, transparent)'
+                  background:
+                      "linear-gradient(to top, rgb(0, 0, 0), rgba(0, 0, 0, 0)), " +
+                      "linear-gradient(to right, rgb(255, 255, 255), rgba(255, 255, 255, 0))"
                 }}
               />
               {/* Color indicator */}


### PR DESCRIPTION
https://github.com/NoRiskClient/issues/issues/2255

Switched the gradients for the background

| Before | After |
| --- | --- |
| <img width="797" height="545" alt="image" src="https://github.com/user-attachments/assets/708645e3-32fe-474c-b4ca-5f5d5a59f3c1" /> | <img width="787" height="534" alt="image" src="https://github.com/user-attachments/assets/fdc82381-ebb3-49c9-afd3-07438375819a" /> | 
