### PR TITLE
fix(minecraft_auth): preserve active state when updating existing acc…

### DIFF
--- a/src-tauri/src/minecraft/auth/minecraft_auth.rs
+++ b/src-tauri/src/minecraft/auth/minecraft_auth.rs
@@ -768,7 +768,12 @@ impl MinecraftAuthStore {
             // Wenn der Account existiert, aktualisiere ihn
             if let Some(existing) = accounts.iter_mut().find(|acc| acc.id == credentials.id) {
                 info!("[Account Manager] Found existing account, updating credentials");
+
+                // Preserve the current active state to avoid race conditions with set_active_account
+                let was_active = existing.active;
                 *existing = credentials;
+                existing.active = was_active;
+
                 info!("[Account Manager] Account successfully updated");
             } else {
                 // Wenn der Account nicht existiert, füge ihn hinzu


### PR DESCRIPTION
- Fixes multi-account launches always using the previously refreshed credentials.
- update_or_insert now keeps the persisted active flag when refreshing stored credentials, preventing background token refreshes from silently reactivating another account.
- Result: launching profile B after switching accounts reliably uses the chosen credentials without needing another in-client switch.