### PR TITLE
fix(time-utils): improve date formatting for older timestamps

### DIFF
--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -22,15 +22,15 @@ export function timeAgo(timestamp: number | null): string {
     return `${Math.round(secondsPast / 3600)}h ago`;
   }
   
-  // For older dates, just show the date
+  // For older dates, just show the calendar date
   const date = new Date(timestamp);
   const day = date.getDate();
   const month = date.toLocaleString('default', { month: 'short' });
   const year = date.getFullYear();
   
-  if (secondsPast <= 86400 * 30) { // Roughly within a month
-     return `${day} ${month} ago`;
+  if (secondsPast <= 86400 * 30) {
+    return `${day} ${month}`;
   }
- 
+
   return `${day} ${month} ${year}`;
 } 


### PR DESCRIPTION
This pull request updates the `timeAgo` utility function to improve how older dates are displayed. The main change is that for dates within the last month, the function now shows just the calendar date instead of appending "ago" to the output.

Improvements to date formatting:

* [`src/utils/time-utils.ts`](diffhunk://#diff-293af8bf6dcc39fee7f38add77ec73bda017a4589fe866b54651ac39ecf3fb72L25-R32): Changed the output for dates within the last month to display as "`day month`" (e.g., "12 Jun") instead of "`day month ago`", and clarified the comment to specify "calendar date" rather than just "date".