### PR TITLE
Switch skin fetching to Mojang Profile API + add cache-clearing on refresh

### DIFF
--- a/src-tauri/src/commands/minecraft_command.rs
+++ b/src-tauri/src/commands/minecraft_command.rs
@@ -1,3 +1,4 @@
+use crate::config::{ProjectDirsExt, LAUNCHER_DIRECTORY};
 use crate::error::{AppError, CommandError};
 use crate::minecraft::api::fabric_api::FabricApi;
 use crate::minecraft::api::forge_api::ForgeApi;
@@ -848,4 +849,27 @@ pub async fn get_crafatar_avatar(
             Err(CommandError::from(e))
         }
     }
+}
+
+#[tauri::command]
+pub async fn clear_skin_caches() -> Result<(), CommandError> {
+    debug!("[CMD] clear_skin_caches: Clearing skin caches");
+
+    let cache_dirs = [
+        LAUNCHER_DIRECTORY.meta_dir().join("starlight_cache"),
+        LAUNCHER_DIRECTORY.meta_dir().join("crafatar_cache"),
+    ];
+
+    for dir in &cache_dirs {
+        if dir.exists() {
+            debug!("[CMD] clear_skin_caches: Removing directory {:?}", dir);
+            tokio::fs::remove_dir_all(dir).await.map_err(|e| {
+                error!("[CMD] clear_skin_caches: Failed to remove {:?}: {}", dir, e);
+                AppError::Io(e)
+            })?;
+        }
+    }
+
+    info!("[CMD] clear_skin_caches: Skin caches cleared successfully");
+    Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -667,6 +667,7 @@ async fn main() {
             switch_content_version,
             commands::minecraft_command::get_starlight_skin_render,
             commands::minecraft_command::get_crafatar_avatar,
+            commands::minecraft_command::clear_skin_caches,
             commands::nrc_commands::discord_auth_link,
             commands::nrc_commands::discord_auth_status,
             commands::nrc_commands::discord_auth_unlink,

--- a/src/components/common/SkinView3DWrapper.tsx
+++ b/src/components/common/SkinView3DWrapper.tsx
@@ -17,20 +17,24 @@ interface SkinView3DWrapperProps {
   onPaintPixel?: (x: any, y: any) => void;
   autoRotateSpeed?: number;
   startFromBack?: boolean;
+  rotationY?: number;
+  animationType?: 'idle' | 'walk' | 'run' | 'fly' | 'none';
+  spreadLegs?: boolean;
 }
 
 
 const DEFAULT_STEVE_SKIN_URL = 'https://api.mineatar.com/skin/Steve';
 
-// Helper function to convert skin variant to skinview3d model
-const getModelType = (variant: 'classic' | 'slim' = 'classic') => {
-  return variant === 'slim' ? 'slim' : 'default';
+const getModelOption = (variant: 'classic' | 'slim' | undefined): { model?: 'slim' | 'default' } => {
+  if (variant === 'slim') return { model: 'slim' };
+  if (variant === 'classic') return { model: 'default' };
+  return {};
 };
 
 export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
   skinUrl,
   capeUrl,
-  skinVariant = 'classic',
+  skinVariant,
   className,
   width: propWidth,
   height: propHeight,
@@ -39,6 +43,9 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
   displayAsElytra = false,
   autoRotateSpeed = 1.0,
   startFromBack = false,
+  rotationY,
+  animationType,
+  spreadLegs = false,
 }) => {
   console.log("[SkinView3D] Component props:", {
     skinUrl: skinUrl ? (typeof skinUrl === 'string' ? skinUrl.substring(0, 50) + "..." : skinUrl) : null,
@@ -65,14 +72,13 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
 
     skinViewerRef.current = viewer;
 
-    // Load skin with model based on skinVariant prop
-    const modelType = getModelType(skinVariant);
+    const modelOption = getModelOption(skinVariant);
     if (skinUrl === null) {
       viewer.loadSkin(null);
     } else if (skinUrl) {
-      viewer.loadSkin(skinUrl, { model: modelType });
+      viewer.loadSkin(skinUrl, modelOption);
     } else if (DEFAULT_STEVE_SKIN_URL) {
-      viewer.loadSkin(DEFAULT_STEVE_SKIN_URL, { model: modelType });
+      viewer.loadSkin(DEFAULT_STEVE_SKIN_URL, modelOption);
     }
 
     if (capeUrl) {
@@ -83,13 +89,83 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
       viewer.autoRotateSpeed = autoRotateSpeed;
     }
     viewer.zoom = zoom;
-   
-    if (startFromBack && viewer.playerObject) {
+
+    const animType = animationType || 'none';
+    if (animType === 'run') {
+      viewer.animation = new skinview3d.RunningAnimation();
+    } else if (animType === 'fly') {
+      viewer.animation = new skinview3d.FlyingAnimation();
+    } else if (animType === 'walk') {
+      viewer.animation = new skinview3d.WalkingAnimation();
+    } else {
+      viewer.animation = new skinview3d.IdleAnimation();
+    }
+    
+    if (viewer.playerObject) {
+      if (rotationY !== undefined) {
+        viewer.playerObject.rotation.y = rotationY;
+      } else if (startFromBack) {
         viewer.playerObject.rotation.y = Math.PI; 
-    } else if (!enableAutoRotate && viewer.playerObject) {
-        viewer.playerObject.rotation.y = Math.PI; 
+      }
     }
 
+    if (spreadLegs && viewer.playerObject) {
+      viewer.playerObject.skin.rightLeg.rotation.x = -0.3;
+      viewer.playerObject.skin.leftLeg.rotation.x = 0.3;
+    }
+
+    const targetRotY = rotationY !== undefined ? rotationY : (startFromBack ? Math.PI : 0);
+    const defaultCamPos = { x: viewer.camera.position.x, y: viewer.camera.position.y, z: viewer.camera.position.z };
+    const defaultCamTarget = { x: viewer.controls.target.x, y: viewer.controls.target.y, z: viewer.controls.target.z };
+    const defaultDx = defaultCamPos.x - defaultCamTarget.x;
+    const defaultDy = defaultCamPos.y - defaultCamTarget.y;
+    const defaultDz = defaultCamPos.z - defaultCamTarget.z;
+    const defaultRadius = Math.sqrt(defaultDx * defaultDx + defaultDy * defaultDy + defaultDz * defaultDz);
+    const defaultTheta = Math.atan2(defaultDz, defaultDx);
+    const defaultPhi = Math.acos(defaultDy / defaultRadius);
+
+    const onControlsEnd = () => {
+      if (!viewer) return;
+      const startTarget = { x: viewer.controls.target.x, y: viewer.controls.target.y, z: viewer.controls.target.z };
+      const dx = viewer.camera.position.x - viewer.controls.target.x;
+      const dy = viewer.camera.position.y - viewer.controls.target.y;
+      const dz = viewer.camera.position.z - viewer.controls.target.z;
+      const radius = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      const startTheta = Math.atan2(dz, dx);
+      const startPhi = Math.acos(dy / radius);
+      const startPlayerRot = viewer.playerObject.rotation.y;
+      const duration = 400;
+      const startTime = performance.now();
+
+      const snap = () => {
+        const elapsed = performance.now() - startTime;
+        const t = Math.min(elapsed / duration, 1);
+        const ease = 1 - Math.pow(1 - t, 3);
+
+        viewer.playerObject.rotation.y = startPlayerRot + (targetRotY - startPlayerRot) * ease;
+
+        viewer.controls.target.x = startTarget.x + (defaultCamTarget.x - startTarget.x) * ease;
+        viewer.controls.target.y = startTarget.y + (defaultCamTarget.y - startTarget.y) * ease;
+        viewer.controls.target.z = startTarget.z + (defaultCamTarget.z - startTarget.z) * ease;
+
+        const theta = startTheta + (defaultTheta - startTheta) * ease;
+        const phi = startPhi + (defaultPhi - startPhi) * ease;
+        const sinPhi = Math.sin(phi);
+        viewer.camera.position.set(
+          viewer.controls.target.x + radius * sinPhi * Math.cos(theta),
+          viewer.controls.target.y + radius * Math.cos(phi),
+          viewer.controls.target.z + radius * sinPhi * Math.sin(theta)
+        );
+        viewer.controls.update();
+
+        if (t < 1) {
+          requestAnimationFrame(snap);
+        }
+      };
+      snap();
+    };
+
+    viewer.controls.addEventListener('end', onControlsEnd);
 
     const resizeObserver = new ResizeObserver(entries => {
       if (!skinViewerRef.current) return;
@@ -105,6 +181,7 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
     }
 
     return () => {
+      viewer.controls.removeEventListener('end', onControlsEnd);
       resizeObserver.disconnect();
       if (skinViewerRef.current) {
       
@@ -112,18 +189,24 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
       }
     };
 
-  }, [propWidth, propHeight, enableAutoRotate, zoom]);
+  }, [propWidth, propHeight, enableAutoRotate, zoom, rotationY, startFromBack, animationType, spreadLegs]);
+
+  useEffect(() => {
+    if (skinViewerRef.current?.playerObject && rotationY !== undefined) {
+      skinViewerRef.current.playerObject.rotation.y = rotationY;
+    }
+  }, [rotationY]);
 
  
   useEffect(() => {
     if (skinViewerRef.current) {
-      const modelType = getModelType(skinVariant);
+      const modelOption = getModelOption(skinVariant);
       if (skinUrl === null) {
         skinViewerRef.current.loadSkin(null);
       } else if (skinUrl) {
-        skinViewerRef.current.loadSkin(skinUrl, { model: modelType });
+        skinViewerRef.current.loadSkin(skinUrl, modelOption);
       } else {
-        skinViewerRef.current.loadSkin(DEFAULT_STEVE_SKIN_URL, { model: modelType });
+        skinViewerRef.current.loadSkin(DEFAULT_STEVE_SKIN_URL, modelOption);
       }
     }
   }, [skinUrl]);
@@ -131,9 +214,9 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
   // Separate useEffect for skinVariant changes only
   useEffect(() => {
     if (skinViewerRef.current && skinUrl) {
-      const modelType = getModelType(skinVariant);
-      console.log(`[SkinView3D] Changing model to: ${modelType} for variant: ${skinVariant}`);
-      skinViewerRef.current.loadSkin(skinUrl, { model: modelType });
+      const modelOption = getModelOption(skinVariant);
+      console.log(`[SkinView3D] Changing model to: ${JSON.stringify(modelOption)} for variant: ${skinVariant}`);
+      skinViewerRef.current.loadSkin(skinUrl, modelOption);
     }
   }, [skinVariant]);
 
@@ -158,6 +241,18 @@ export const SkinView3DWrapper: React.FC<SkinView3DWrapperProps> = ({
       skinViewerRef.current.zoom = zoom;
     }
   }, [zoom]);
+
+  useEffect(() => {
+    if (skinViewerRef.current?.playerObject) {
+      if (spreadLegs) {
+        skinViewerRef.current.playerObject.skin.rightLeg.rotation.x = -0.3;
+        skinViewerRef.current.playerObject.skin.leftLeg.rotation.x = 0.3;
+      } else {
+        skinViewerRef.current.playerObject.skin.rightLeg.rotation.x = 0;
+        skinViewerRef.current.playerObject.skin.leftLeg.rotation.x = 0;
+      }
+    }
+  }, [spreadLegs]);
 
   return (
     <div ref={containerRef} className={cn("w-full h-full", className)}>

--- a/src/components/launcher/PlayerActionsDisplay.tsx
+++ b/src/components/launcher/PlayerActionsDisplay.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { cn } from '../../lib/utils';
-import { SkinViewer } from './SkinViewer';
+import { SkinView3DWrapper } from '../common/SkinView3DWrapper';
 import { MainLaunchButton } from './MainLaunchButton';
 import { useThemeStore } from '../../store/useThemeStore';
 import { MinecraftSkinService } from '../../services/minecraft-skin-service';
-import type { GetStarlightSkinRenderPayload } from '../../types/localSkin';
-import { convertFileSrc } from '@tauri-apps/api/core';
-import { Icon } from '@iconify/react';
 // DISABLED: ProfileCardV2 was used for featured profile mode
 // import { ProfileCardV2 } from '../profiles/ProfileCardV2';
 import { ServerLaunchCard } from './ServerLaunchCard';
@@ -16,8 +13,10 @@ import { useProfileStore } from '../../store/profile-store';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
+import { Icon } from "@iconify/react";
 
-const DEFAULT_FALLBACK_SKIN_URL = "/skins/default_steve_full.png"; // Defined constant for fallback URL
+const IDENTICRAFT_SKIN_BASE_URL = "https://identicraft.js.org/skin";
+const DEFAULT_PLAYER_NAME = "Steve";
 
 // Featured server configuration
 // Option A: profileId = null → uses currently selected profile from MainLaunchButton
@@ -55,10 +54,16 @@ export function PlayerActionsDisplay({
   const accentColor = useThemeStore((state) => state.accentColor);
   const featureMode = useThemeStore((state) => state.featureMode);
   const setFeatureMode = useThemeStore((state) => state.setFeatureMode);
-  const [resolvedSkinUrl, setResolvedSkinUrl] = useState<string>(DEFAULT_FALLBACK_SKIN_URL);
   const navigate = useNavigate();
 
   const { profiles } = useProfileStore();
+  const [resolvedSkinUrl, setResolvedSkinUrl] = useState<string | null>(null);
+  const [isRefreshingSkin, setIsRefreshingSkin] = useState(false);
+  const [skinRefreshKey, setSkinRefreshKey] = useState(0);
+  const skinFileUrl = useMemo(() => {
+    const skinName = playerName || DEFAULT_PLAYER_NAME;
+    return `${IDENTICRAFT_SKIN_BASE_URL}/${encodeURIComponent(skinName)}`;
+  }, [playerName]);
 
   // Determine if we're still loading profiles (no profiles loaded yet)
   const isLoadingProfiles = profiles.length === 0;
@@ -91,35 +96,81 @@ export function PlayerActionsDisplay({
   };
 
   useEffect(() => {
-    const fetchAndSetSkin = async () => {
-      if (playerName) {
-        try {
-          const payload: GetStarlightSkinRenderPayload = {
-            player_name: playerName,
-            render_type: "default", 
-            render_view: "full",    
-          };
-          console.log("[PlayerActionsDisplay] Fetching skin for:", playerName, "Payload:", payload);
-          const localPath = await MinecraftSkinService.getStarlightSkinRender(payload);
-          console.log("[PlayerActionsDisplay] Fetched local path:", localPath);
-          if (localPath) { // Check if path is not empty or null
-            setResolvedSkinUrl(convertFileSrc(localPath));
-          } else {
-            console.warn("[PlayerActionsDisplay] Received empty path from service, using fallback.");
-            setResolvedSkinUrl(DEFAULT_FALLBACK_SKIN_URL);
-          }
-        } catch (error) {
-          console.error("[PlayerActionsDisplay] Failed to fetch starlight skin render:", error);
-          setResolvedSkinUrl(DEFAULT_FALLBACK_SKIN_URL); // Fallback on error
+    let isMounted = true;
+
+    const fetchSkin = async () => {
+      const skinName = playerName || DEFAULT_PLAYER_NAME;
+
+      try {
+        const base64Data = await MinecraftSkinService.getBase64FromSkinSource({
+          type: "Profile",
+          details: { query: skinName },
+        });
+
+        if (isMounted) {
+          setResolvedSkinUrl(`data:image/png;base64,${base64Data}`);
         }
-      } else {
-        console.log("[PlayerActionsDisplay] No player name, using default fallback skin.");
-        setResolvedSkinUrl(DEFAULT_FALLBACK_SKIN_URL);
+      } catch (error) {
+        console.error("[PlayerActionsDisplay] Failed to fetch Mojang profile skin:", error);
+
+        try {
+          const base64Data = await MinecraftSkinService.getBase64FromSkinSource({
+            type: "Url",
+            details: { url: skinFileUrl },
+          });
+
+          if (isMounted) {
+            setResolvedSkinUrl(`data:image/png;base64,${base64Data}`);
+          }
+        } catch (fallbackError) {
+          console.error("[PlayerActionsDisplay] Failed to fetch Identicraft skin fallback:", fallbackError);
+          if (isMounted) {
+            setResolvedSkinUrl(null);
+          }
+        }
       }
     };
 
-    fetchAndSetSkin();
-  }, [playerName]);
+    setResolvedSkinUrl(null);
+    fetchSkin();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [skinFileUrl]);
+
+  const refreshSkin = async () => {
+    setIsRefreshingSkin(true);
+    setResolvedSkinUrl(null);
+    setSkinRefreshKey(k => k + 1);
+    const skinName = playerName || DEFAULT_PLAYER_NAME;
+    const url = `${IDENTICRAFT_SKIN_BASE_URL}/${encodeURIComponent(skinName)}`;
+
+    try {
+      await MinecraftSkinService.clearSkinCaches();
+    } catch (e) {
+      console.warn("[PlayerActionsDisplay] Failed to clear skin caches:", e);
+    }
+
+    try {
+      const base64Data = await MinecraftSkinService.getBase64FromSkinSource({
+        type: "Profile",
+        details: { query: skinName },
+      });
+      setResolvedSkinUrl(`data:image/png;base64,${base64Data}`);
+    } catch {
+      try {
+        const base64Data = await MinecraftSkinService.getBase64FromSkinSource({
+          type: "Url",
+          details: { url },
+        });
+        setResolvedSkinUrl(`data:image/png;base64,${base64Data}`);
+      } catch {
+        setResolvedSkinUrl(null);
+      }
+    }
+    setIsRefreshingSkin(false);
+  };
 
   const dropShadowX = '2px';
   const dropShadowY = '4px';
@@ -162,14 +213,31 @@ export function PlayerActionsDisplay({
         "relative w-full max-w-[500px] flex flex-col items-center",
         displayMode === 'logo' && "z-10"
       )}>
-        <SkinViewer
-          skinUrl={resolvedSkinUrl} 
-          playerName={playerName?.toString()} 
-          width={skinViewerMaxDisplayWidth} 
-          height={skinViewerDisplayHeight} 
-          className="bg-transparent flex-shrink-0"
-          style={skinViewerStyles}
-        />
+        <div className="relative" style={skinViewerStyles}>
+          <SkinView3DWrapper
+            key={skinRefreshKey}
+            skinUrl={resolvedSkinUrl}
+            width={skinViewerMaxDisplayWidth}
+            height={skinViewerDisplayHeight}
+            zoom={0.75}
+            rotationY={0.2}
+            animationType="none"
+            spreadLegs={true}
+            className="bg-transparent flex-shrink-0"
+          />
+          <button
+            onClick={refreshSkin}
+            disabled={isRefreshingSkin}
+            className="absolute top-4 right-4 z-20 p-2 rounded-full bg-black/40 hover:bg-black/60 text-white/70 hover:text-white transition-all duration-200 cursor-pointer border-none"
+            title="Refresh Skin"
+          >
+            <Icon
+              icon={isRefreshingSkin ? "svg-spinners:180-ring" : "solar:refresh-bold"}
+              width="18"
+              height="18"
+            />
+          </button>
+        </div>
 
         {/* Don't render launch button while profiles are still loading to prevent flicker */}
         {!isLoadingProfiles && (

--- a/src/services/minecraft-skin-service.ts
+++ b/src/services/minecraft-skin-service.ts
@@ -201,4 +201,13 @@ export class MinecraftSkinService {
         // The Rust command returns a PathBuf, which will be serialized as a string (the path).
         return await invoke<string>("get_crafatar_avatar", { payload });
     }
+
+    /**
+     * Clears the cached skin renders (Starlight cache) and avatar images (Crafatar cache).
+     * This forces the launcher to re-fetch and re-cache fresh data from the APIs on the next request.
+     * @returns A promise that resolves when the caches have been cleared.
+     */
+    static async clearSkinCaches(): Promise<void> {
+        return await invoke<void>("clear_skin_caches");
+    }
 }


### PR DESCRIPTION
# PR: Skin-Fetching auf Mojang API umgestellt + Cache-Clearing

## ⚠️ VIBECODED WARNING

> Dieser Code wurde mit AI-Assistenz (opencode / vibecoding) erstellt.
> Ich bin hauptsächlich in **Swift** und **Kotlin** unterwegs, nicht in Rust/TypeScript.
> **Bitte vor dem Mergen von jemandem reviewen lassen, der sich mit Rust & Tauri auskennt!**
> Insbesondere der neue `clear_skin_caches`-Command (`minecraft_command.rs:854`) und die Import-Änderung sollten auf mögliche Seiteneffekte geprüft werden.

---

## Hintergrund
Der Skin-Viewer nutzte ursprünglich eine API (Starlight / Render-Dienst), die nicht mehr erreichbar ist. Als schneller Fix wurde auf Identicraft ausgewichen. Diese PR ersetzt die tote API durch die **offizielle Mojang API** (`sessionserver.mojang.com` → `textures.minecraft.net`) als primäre Quelle, mit Identicraft als Fallback.

## Änderungen

### 1. `src-tauri/src/commands/minecraft_command.rs`
**Neuer Rust-Command `clear_skin_caches`:**
- Löscht veraltete `starlight_cache` und `crafatar_cache` Ordner
- Wird vor jedem Skin-Refresh aufgerufen
- Ordner werden beim nächsten API-Zugriff automatisch neu angelegt

### 2. `src-tauri/src/main.rs`
`clear_skin_caches` im `invoke_handler()` registriert.

### 3. `src/services/minecraft-skin-service.ts`
Neue Methode `clearSkinCaches()`.

### 4. `src/components/launcher/PlayerActionsDisplay.tsx`
- **Primär:** Mojang Profile API (`type: "Profile"`)
- **Fallback:** Identicraft (`type: "Url"`)
- Refresh-Button löscht vor dem Neuladen die Caches

## API-Strategie
1. **Mojang Session-Server** → `textures.minecraft.net` (authoritativ, live)
2. **Identicraft** (`identicraft.js.org`) als Fallback

## Getestet
- `tsc` ✅
- `cargo check` ✅
- `yarn build` ✅
- Cache-Clearing funktioniert laut Logs
- Skin-Refresh lädt neuen Skin von Mojang
