### PR TITLE
feat: add RPM and Pacman package support to Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf rpm
 
       - name: setup node
         uses: actions/setup-node@v4
@@ -181,7 +181,17 @@ jobs:
           
           # Verschiebe und benenne Deb Signatur um
           mv "$DEB_DIR"/*.deb.sig "$APPIMAGE_DIR"/${{ matrix.asset_name_base }}.deb.sig
-          
+
+          # RPM
+          RPM_DIR=${{ matrix.output_path }}/rpm
+          mv "$RPM_DIR"/*.rpm "$APPIMAGE_DIR"/${{ matrix.asset_name_base }}.rpm
+          mv "$RPM_DIR"/*.rpm.sig "$APPIMAGE_DIR"/${{ matrix.asset_name_base }}.rpm.sig || true
+
+          # Pacman
+          PACMAN_DIR=${{ matrix.output_path }}/pacman
+          mv "$PACMAN_DIR"/*.pkg.tar.gz "$APPIMAGE_DIR"/${{ matrix.asset_name_base }}.pkg.tar.gz
+          mv "$PACMAN_DIR"/*.pkg.tar.gz.sig "$APPIMAGE_DIR"/${{ matrix.asset_name_base }}.pkg.tar.gz.sig || true
+
           echo "Final content of $APPIMAGE_DIR after moves"
           ls -R "$APPIMAGE_DIR" || true
           


### PR DESCRIPTION
- Add `rpm` tool to Ubuntu build dependencies (required by Tauri's RPM bundler)
- Collect and rename .rpm and .pkg.tar.gz (Pacman) artifacts after build
- Existing upload wildcard picks them up automatically, no further changes needed

Tauri v2 already builds all Linux targets (deb, appimage, rpm, pacman) since bundle.targets is unset. This PR only wires up artifact collection and release.

Tested locally on Fedora 44: RPM builds and installs correctly.