### PR TITLE
Perf/logs backend ranges

### DIFF
--- a/src-tauri/src/commands/process_command.rs
+++ b/src-tauri/src/commands/process_command.rs
@@ -306,3 +306,28 @@ pub async fn focus_main_window<R: tauri::Runtime>(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_log_session_id() {
+        assert!(validate_log_session_id("valid-session-123").is_ok());
+        assert!(validate_log_session_id("abc_def-123").is_ok());
+
+        assert!(validate_log_session_id("").is_err());
+        assert!(validate_log_session_id("session/id").is_err());
+        assert!(validate_log_session_id("session\\id").is_err());
+        assert!(validate_log_session_id("session..id").is_err());
+    }
+
+    #[test]
+    fn test_clamp_log_read_len() {
+        assert_eq!(clamp_log_read_len(None), MAX_LOG_CURSOR_BYTES);
+        assert_eq!(clamp_log_read_len(Some(100)), 100);
+        assert_eq!(clamp_log_read_len(Some(0)), 1);
+        assert_eq!(clamp_log_read_len(Some(MAX_LOG_CURSOR_BYTES + 100)), MAX_LOG_CURSOR_BYTES);
+    }
+}
+

--- a/src-tauri/src/commands/process_command.rs
+++ b/src-tauri/src/commands/process_command.rs
@@ -7,7 +7,7 @@ use tauri::Manager;
 use uuid::Uuid;
 
 const PROCESS_LOG_FILE_NAME: &str = "nrc-process.log";
-const MAX_LOG_RANGE_BYTES: u64 = 512 * 1024;
+const MAX_LOG_CURSOR_BYTES: u64 = 512 * 1024;
 
 #[tauri::command]
 pub async fn get_processes() -> Result<Vec<ProcessMetadata>, CommandError> {
@@ -47,14 +47,7 @@ pub struct ProcessLogCursor {
     pub cursor: u64,
     pub output: String,
     pub new_file: bool,
-}
-
-#[derive(serde::Serialize)]
-pub struct ProcessLogRange {
-    pub start: u64,
-    pub cursor: u64,
     pub total_bytes: u64,
-    pub output: String,
     pub truncated: bool,
 }
 
@@ -78,14 +71,17 @@ fn process_log_path(session_id: &str) -> PathBuf {
         .join(PROCESS_LOG_FILE_NAME)
 }
 
-fn clamp_log_read_len(requested: u64) -> u64 {
-    requested.clamp(1, MAX_LOG_RANGE_BYTES)
+fn clamp_log_read_len(requested: Option<u64>) -> u64 {
+    requested
+        .unwrap_or(MAX_LOG_CURSOR_BYTES)
+        .clamp(1, MAX_LOG_CURSOR_BYTES)
 }
 
 #[tauri::command]
 pub async fn get_process_log_cursor(
     session_id: String,
     cursor: u64,
+    max_bytes: Option<u64>,
 ) -> Result<ProcessLogCursor, CommandError> {
     use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
@@ -97,60 +93,22 @@ pub async fn get_process_log_cursor(
             cursor: 0,
             output: String::new(),
             new_file: false,
-        });
-    }
-
-    let mut file = tokio::fs::File::open(&path).await.map_err(AppError::Io)?;
-    let len = file.metadata().await.map_err(AppError::Io)?.len();
-
-    let mut cursor = cursor;
-    let mut new_file = false;
-    if cursor > len {
-        cursor = 0;
-        new_file = true;
-    }
-
-    file.seek(std::io::SeekFrom::Start(cursor))
-        .await
-        .map_err(AppError::Io)?;
-    let mut buf = Vec::new();
-    let read = file.read_to_end(&mut buf).await.map_err(AppError::Io)?;
-
-    let output =
-        crate::utils::security_utils::mask_sensitive_data(&String::from_utf8_lossy(&buf));
-
-    Ok(ProcessLogCursor {
-        cursor: cursor + read as u64,
-        output,
-        new_file,
-    })
-}
-
-#[tauri::command]
-pub async fn get_process_log_range(
-    session_id: String,
-    start: u64,
-    max_bytes: Option<u64>,
-) -> Result<ProcessLogRange, CommandError> {
-    use tokio::io::{AsyncReadExt, AsyncSeekExt};
-
-    validate_log_session_id(&session_id)?;
-    let path = process_log_path(&session_id);
-
-    if !path.exists() {
-        return Ok(ProcessLogRange {
-            start: 0,
-            cursor: 0,
             total_bytes: 0,
-            output: String::new(),
             truncated: false,
         });
     }
 
     let mut file = tokio::fs::File::open(&path).await.map_err(AppError::Io)?;
     let total_bytes = file.metadata().await.map_err(AppError::Io)?.len();
-    let read_start = start.min(total_bytes);
-    let read_len = clamp_log_read_len(max_bytes.unwrap_or(MAX_LOG_RANGE_BYTES));
+
+    let mut read_start = cursor;
+    let mut new_file = false;
+    if read_start > total_bytes {
+        read_start = 0;
+        new_file = true;
+    }
+
+    let read_len = clamp_log_read_len(max_bytes);
     let available = total_bytes.saturating_sub(read_start);
     let bounded_read_len = read_len.min(available);
 
@@ -161,42 +119,18 @@ pub async fn get_process_log_range(
     let mut buf = Vec::with_capacity(bounded_read_len as usize);
     let mut reader = file.take(bounded_read_len);
     let read = reader.read_to_end(&mut buf).await.map_err(AppError::Io)?;
-    let cursor = read_start + read as u64;
+    let next_cursor = read_start + read as u64;
+
     let output =
         crate::utils::security_utils::mask_sensitive_data(&String::from_utf8_lossy(&buf));
 
-    Ok(ProcessLogRange {
-        start: read_start,
-        cursor,
-        total_bytes,
+    Ok(ProcessLogCursor {
+        cursor: next_cursor,
         output,
-        truncated: cursor < total_bytes,
+        new_file,
+        total_bytes,
+        truncated: next_cursor < total_bytes,
     })
-}
-
-#[tauri::command]
-pub async fn get_process_log_tail(
-    session_id: String,
-    max_bytes: Option<u64>,
-) -> Result<ProcessLogRange, CommandError> {
-    validate_log_session_id(&session_id)?;
-    let path = process_log_path(&session_id);
-
-    if !path.exists() {
-        return Ok(ProcessLogRange {
-            start: 0,
-            cursor: 0,
-            total_bytes: 0,
-            output: String::new(),
-            truncated: false,
-        });
-    }
-
-    let total_bytes = tokio::fs::metadata(&path).await.map_err(AppError::Io)?.len();
-    let read_len = clamp_log_read_len(max_bytes.unwrap_or(MAX_LOG_RANGE_BYTES));
-    let start = total_bytes.saturating_sub(read_len);
-
-    get_process_log_range(session_id, start, Some(read_len)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/process_command.rs
+++ b/src-tauri/src/commands/process_command.rs
@@ -2,8 +2,12 @@ use crate::error::{AppError, CommandError};
 use crate::state::process_state::ProcessMetadata;
 use crate::state::state_manager::State;
 use chrono::{DateTime, Utc};
+use std::path::PathBuf;
 use tauri::Manager;
 use uuid::Uuid;
+
+const PROCESS_LOG_FILE_NAME: &str = "nrc-process.log";
+const MAX_LOG_RANGE_BYTES: u64 = 512 * 1024;
 
 #[tauri::command]
 pub async fn get_processes() -> Result<Vec<ProcessMetadata>, CommandError> {
@@ -45,13 +49,16 @@ pub struct ProcessLogCursor {
     pub new_file: bool,
 }
 
-#[tauri::command]
-pub async fn get_process_log_cursor(
-    session_id: String,
-    cursor: u64,
-) -> Result<ProcessLogCursor, CommandError> {
-    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+#[derive(serde::Serialize)]
+pub struct ProcessLogRange {
+    pub start: u64,
+    pub cursor: u64,
+    pub total_bytes: u64,
+    pub output: String,
+    pub truncated: bool,
+}
 
+fn validate_log_session_id(session_id: &str) -> Result<(), CommandError> {
     if session_id.is_empty()
         || session_id.contains('/')
         || session_id.contains('\\')
@@ -62,9 +69,28 @@ pub async fn get_process_log_cursor(
         ))));
     }
 
-    let path = crate::utils::log_archive::archive_root()
-        .join(&session_id)
-        .join("nrc-process.log");
+    Ok(())
+}
+
+fn process_log_path(session_id: &str) -> PathBuf {
+    crate::utils::log_archive::archive_root()
+        .join(session_id)
+        .join(PROCESS_LOG_FILE_NAME)
+}
+
+fn clamp_log_read_len(requested: u64) -> u64 {
+    requested.clamp(1, MAX_LOG_RANGE_BYTES)
+}
+
+#[tauri::command]
+pub async fn get_process_log_cursor(
+    session_id: String,
+    cursor: u64,
+) -> Result<ProcessLogCursor, CommandError> {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    validate_log_session_id(&session_id)?;
+    let path = process_log_path(&session_id);
 
     if !path.exists() {
         return Ok(ProcessLogCursor {
@@ -98,6 +124,79 @@ pub async fn get_process_log_cursor(
         output,
         new_file,
     })
+}
+
+#[tauri::command]
+pub async fn get_process_log_range(
+    session_id: String,
+    start: u64,
+    max_bytes: Option<u64>,
+) -> Result<ProcessLogRange, CommandError> {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    validate_log_session_id(&session_id)?;
+    let path = process_log_path(&session_id);
+
+    if !path.exists() {
+        return Ok(ProcessLogRange {
+            start: 0,
+            cursor: 0,
+            total_bytes: 0,
+            output: String::new(),
+            truncated: false,
+        });
+    }
+
+    let mut file = tokio::fs::File::open(&path).await.map_err(AppError::Io)?;
+    let total_bytes = file.metadata().await.map_err(AppError::Io)?.len();
+    let read_start = start.min(total_bytes);
+    let read_len = clamp_log_read_len(max_bytes.unwrap_or(MAX_LOG_RANGE_BYTES));
+    let available = total_bytes.saturating_sub(read_start);
+    let bounded_read_len = read_len.min(available);
+
+    file.seek(std::io::SeekFrom::Start(read_start))
+        .await
+        .map_err(AppError::Io)?;
+
+    let mut buf = Vec::with_capacity(bounded_read_len as usize);
+    let mut reader = file.take(bounded_read_len);
+    let read = reader.read_to_end(&mut buf).await.map_err(AppError::Io)?;
+    let cursor = read_start + read as u64;
+    let output =
+        crate::utils::security_utils::mask_sensitive_data(&String::from_utf8_lossy(&buf));
+
+    Ok(ProcessLogRange {
+        start: read_start,
+        cursor,
+        total_bytes,
+        output,
+        truncated: cursor < total_bytes,
+    })
+}
+
+#[tauri::command]
+pub async fn get_process_log_tail(
+    session_id: String,
+    max_bytes: Option<u64>,
+) -> Result<ProcessLogRange, CommandError> {
+    validate_log_session_id(&session_id)?;
+    let path = process_log_path(&session_id);
+
+    if !path.exists() {
+        return Ok(ProcessLogRange {
+            start: 0,
+            cursor: 0,
+            total_bytes: 0,
+            output: String::new(),
+            truncated: false,
+        });
+    }
+
+    let total_bytes = tokio::fs::metadata(&path).await.map_err(AppError::Io)?.len();
+    let read_len = clamp_log_read_len(max_bytes.unwrap_or(MAX_LOG_RANGE_BYTES));
+    let start = total_bytes.saturating_sub(read_len);
+
+    get_process_log_range(session_id, start, Some(read_len)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/utils/string_utils.rs
+++ b/src-tauri/src/utils/string_utils.rs
@@ -6,6 +6,7 @@
 ///
 /// # Example
 /// ```
+/// use noriskclient_launcher_v3_lib::utils::string_utils::safe_truncate;
 /// let korean = "안녕하세요"; // Korean greeting
 /// let truncated = safe_truncate(korean, 5);
 /// // Returns "안" (3 bytes) instead of panicking at byte 5

--- a/src/components/log/LogViewerCore.tsx
+++ b/src/components/log/LogViewerCore.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, useDeferredValue } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@iconify/react";
 import { toast } from "react-hot-toast";
@@ -39,33 +39,22 @@ function getLevelColorClass(level: LogLevel | undefined): string {
   }
 }
 
-interface DisplayLogLine {
-  id: string;
-  timestamp: string | null;
-  level: LogLevel;
-  thread: string | null;
-  message: string;
-  processId: string;
-}
-
-// Convert LogEntry to DisplayLogLine
-function logEntryToDisplayLine(entry: LogEntry): DisplayLogLine {
-  const timestamp = entry.timestamp
-    ? entry.timestamp.toLocaleTimeString("de-DE", {
+function formatTimestamp(timestamp: Date | null): string | null {
+  return timestamp
+    ? timestamp.toLocaleTimeString("de-DE", {
         hour: "2-digit",
         minute: "2-digit",
         second: "2-digit",
       })
     : null;
+}
 
-  return {
-    id: entry.id,
-    timestamp,
-    level: entry.level,
-    thread: entry.thread,
-    message: entry.message,
-    processId: entry.processId,
-  };
+function formatLogEntry(log: LogEntry): string {
+  const timestamp = formatTimestamp(log.timestamp);
+  if (timestamp) {
+    return `[${timestamp}] [${log.thread || "main"}/${log.level}] ${log.message}`;
+  }
+  return `    ${log.message}`;
 }
 
 export interface LogViewerCoreProps {
@@ -97,6 +86,7 @@ export function LogViewerCore({
   const accentColor = useThemeStore((state) => state.accentColor);
   const { showThreadPrefix, toggleShowThreadPrefix } = useLogSettingsStore();
   const [searchTerm, setSearchTerm] = useState("");
+  const deferredSearchTerm = useDeferredValue(searchTerm);
   const [levelFilters, setLevelFilters] = useState<Record<LogLevel, boolean>>({
     ERROR: true,
     WARN: true,
@@ -112,33 +102,26 @@ export function LogViewerCore({
   const fileDropdownButtonRef = useRef<HTMLButtonElement>(null);
   const fileDropdownRef = useRef<HTMLDivElement>(null);
   const [isFileDropdownOpen, setIsFileDropdownOpen] = useState(false);
-  const logContainerRef = useRef<HTMLDivElement>(null);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
-  const isUserScrollingRef = useRef(false);
 
   // State for delayed "NO LOGS YET" display
   const [showNoLogs, setShowNoLogs] = useState(false);
 
-  // Convert log entries to display format
-  const displayLogs = useMemo(() => {
-    return logs.map(logEntryToDisplayLine);
-  }, [logs]);
-
-  // Filter logs based on search and level filters
+  // Filter logs based on search and level filters. Search uses React deferred input
+  // so large log tails do not rescan synchronously on every keystroke.
   const filteredLogs = useMemo(() => {
-    return displayLogs.filter((log) => {
+    const searchLower = deferredSearchTerm.trim().toLowerCase();
+    return logs.filter((log) => {
       if (!levelFilters[log.level]) return false;
-      if (searchTerm) {
-        const searchLower = searchTerm.toLowerCase();
-        return (
-          log.message.toLowerCase().includes(searchLower) ||
-          log.thread?.toLowerCase().includes(searchLower) ||
-          log.level.toLowerCase().includes(searchLower)
-        );
-      }
-      return true;
+      if (!searchLower) return true;
+
+      return (
+        log.message.toLowerCase().includes(searchLower) ||
+        log.thread?.toLowerCase().includes(searchLower) ||
+        log.level.toLowerCase().includes(searchLower)
+      );
     });
-  }, [displayLogs, levelFilters, searchTerm]);
+  }, [logs, levelFilters, deferredSearchTerm]);
 
   // Delay showing "NO LOGS YET" by 1 second to avoid flicker
   useEffect(() => {
@@ -175,44 +158,26 @@ export function LogViewerCore({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isSettingsOpen, isFileDropdownOpen]);
 
-  // Check if scrolled to bottom
-  const isAtBottom = useCallback(() => {
-    if (!logContainerRef.current) return true;
-    const { scrollTop, scrollHeight, clientHeight } = logContainerRef.current;
-    return scrollHeight - scrollTop - clientHeight < 20;
-  }, []);
-
-  // Handle scroll events
-  const handleScroll = useCallback(() => {
-    if (!logContainerRef.current) return;
-
-    if (isAtBottom()) {
-      if (!isAutoscrollEnabled) {
-        setIsAutoscrollEnabled(true);
-      }
-    } else {
-      if (isAutoscrollEnabled && !isUserScrollingRef.current) {
-        setIsAutoscrollEnabled(false);
-      }
-    }
-  }, [isAtBottom, isAutoscrollEnabled]);
-
-  // Auto-scroll effect — use Virtuoso's API
-  useEffect(() => {
-    if (isAutoscrollEnabled && virtuosoRef.current && filteredLogs.length > 0) {
-      isUserScrollingRef.current = true;
-      virtuosoRef.current.scrollToIndex({ index: filteredLogs.length - 1, behavior: "auto" });
-      setTimeout(() => {
-        isUserScrollingRef.current = false;
-      }, 50);
-    }
-  }, [filteredLogs, isAutoscrollEnabled]);
-
   const toggleLevelFilter = (level: LogLevel) => {
     setLevelFilters((prev) => ({ ...prev, [level]: !prev[level] }));
   };
 
   const [isUploading, setIsUploading] = useState(false);
+
+  const copyLogs = async (entries: LogEntry[], label: string) => {
+    if (entries.length === 0) {
+      toast.error(t('logs.no_logs_to_upload'));
+      return;
+    }
+
+    try {
+      await writeText(entries.map(formatLogEntry).join("\n"));
+      toast.success(`${label} copied`);
+    } catch (error) {
+      console.error("Failed to copy logs:", error);
+      toast.error("Failed to copy logs");
+    }
+  };
 
   const handleUpload = async () => {
     if (filteredLogs.length === 0) {
@@ -222,16 +187,7 @@ export function LogViewerCore({
 
     setIsUploading(true);
     try {
-      const logText = filteredLogs
-        .map((log) => {
-          // For lines with timestamp, use full format
-          if (log.timestamp) {
-            return `[${log.timestamp}] [${log.thread || "main"}/${log.level}] ${log.message}`;
-          }
-          // For continuation lines (no timestamp), just use the message with indentation
-          return `    ${log.message}`;
-        })
-        .join("\n");
+      const logText = filteredLogs.map(formatLogEntry).join("\n");
 
       // Use Tauri backend command instead of direct fetch (CSP blocked in production)
       const url = await uploadLogToMclogs(logText);
@@ -351,7 +307,6 @@ export function LogViewerCore({
 
       {/* Log Content */}
       <div
-        ref={logContainerRef}
         className="flex-1 overflow-hidden p-4 font-mono text-sm rounded-lg bg-black/60 backdrop-blur-sm"
         style={{ boxShadow: `0 4px 20px ${accentColor.value}15` }}
       >
@@ -371,20 +326,34 @@ export function LogViewerCore({
             className="custom-scrollbar"
             style={{ height: "100%" }}
             data={filteredLogs}
-            followOutput={() => isAutoscrollEnabled ? "auto" : false}
+            followOutput={isAutoscrollEnabled ? "auto" : false}
+            atBottomStateChange={setIsAutoscrollEnabled}
             initialTopMostItemIndex={filteredLogs.length > 0 ? filteredLogs.length - 1 : 0}
-            itemContent={(_index, log) => (
-              <div className="flex flex-nowrap items-start py-0.5 hover:bg-white/5 px-2 -mx-2 rounded">
-                {log.timestamp ? (
-                  <>
-                    <span className={`pr-2 select-none ${getLevelColorClass(log.level)}`}>
-                      <span className="opacity-80">[{log.timestamp}]</span>
-                      {showThreadPrefix && (
-                        <span className="opacity-80 ml-1">
-                          [{log.thread}/{log.level}]
-                        </span>
-                      )}
-                    </span>
+            itemContent={(_index, log) => {
+              const timestamp = formatTimestamp(log.timestamp);
+              return (
+                <div className="flex flex-nowrap items-start py-0.5 hover:bg-white/5 px-2 -mx-2 rounded">
+                  {timestamp ? (
+                    <>
+                      <span className={`pr-2 select-none ${getLevelColorClass(log.level)}`}>
+                        <span className="opacity-80">[{timestamp}]</span>
+                        {showThreadPrefix && (
+                          <span className="opacity-80 ml-1">
+                            [{log.thread}/{log.level}]
+                          </span>
+                        )}
+                      </span>
+                      <span
+                        className={`flex-1 min-w-0 break-words whitespace-pre-wrap ${
+                          log.level === "ERROR" || log.level === "WARN"
+                            ? getLevelColorClass(log.level)
+                            : "text-white/90"
+                        }`}
+                      >
+                        {log.message}
+                      </span>
+                    </>
+                  ) : (
                     <span
                       className={`flex-1 min-w-0 break-words whitespace-pre-wrap ${
                         log.level === "ERROR" || log.level === "WARN"
@@ -394,20 +363,10 @@ export function LogViewerCore({
                     >
                       {log.message}
                     </span>
-                  </>
-                ) : (
-                  <span
-                    className={`flex-1 min-w-0 break-words whitespace-pre-wrap ${
-                      log.level === "ERROR" || log.level === "WARN"
-                        ? getLevelColorClass(log.level)
-                        : "text-white/90"
-                    }`}
-                  >
-                    {log.message}
-                  </span>
-                )}
-              </div>
-            )}
+                  )}
+                </div>
+              );
+            }}
           />
         )}
       </div>
@@ -449,6 +408,22 @@ export function LogViewerCore({
         </div>
 
         <div className="flex items-center gap-2">
+          <button
+            onClick={() => copyLogs(filteredLogs, "Visible logs")}
+            disabled={filteredLogs.length === 0}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded hover:bg-white/10 transition-colors text-white/60 hover:text-white/90 font-minecraft-ten text-xs disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Icon icon="solar:copy-bold" className="w-4 h-4" />
+            COPY VISIBLE
+          </button>
+          <button
+            onClick={() => copyLogs(logs, "All retained logs")}
+            disabled={logs.length === 0}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded hover:bg-white/10 transition-colors text-white/60 hover:text-white/90 font-minecraft-ten text-xs disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Icon icon="solar:copy-bold" className="w-4 h-4" />
+            COPY ALL
+          </button>
           {onClear && (
             <button
               onClick={onClear}

--- a/src/hooks/useProcessLogCursor.ts
+++ b/src/hooks/useProcessLogCursor.ts
@@ -3,6 +3,7 @@ import { useProcessStore } from "../store/useProcessStore";
 import { getProcessLogCursor } from "../services/process-service";
 
 const POLL_INTERVAL_MS = 700;
+const INGEST_FLUSH_INTERVAL_MS = 150;
 
 export function useProcessLogCursor(
   sessionId: string | null | undefined,
@@ -11,29 +12,53 @@ export function useProcessLogCursor(
   useEffect(() => {
     if (!sessionId || !processId) return;
     let cancelled = false;
+    let isPolling = false;
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    const pendingLines: string[] = [];
+
+    const flushPendingLines = () => {
+      flushTimer = null;
+      if (cancelled || pendingLines.length === 0) return;
+
+      const lines = pendingLines.splice(0, pendingLines.length);
+      useProcessStore.getState().addLogEntriesBatch(
+        lines.map((line) => ({ processId, rawMessage: line })),
+      );
+    };
+
+    const queueLines = (lines: string[]) => {
+      if (lines.length === 0) return;
+      pendingLines.push(...lines);
+
+      if (flushTimer === null) {
+        flushTimer = setTimeout(flushPendingLines, INGEST_FLUSH_INTERVAL_MS);
+      }
+    };
 
     const tick = async () => {
-      if (cancelled) return;
+      if (cancelled || isPolling) return;
+      isPolling = true;
       const store = useProcessStore.getState();
       const cursor = store.cursors.get(processId) ?? 0;
       try {
         const res = await getProcessLogCursor(sessionId, cursor);
         if (cancelled) return;
         if (res.new_file) {
+          pendingLines.splice(0, pendingLines.length);
           store.clearLogs(processId);
         }
         if (res.output) {
-          const entries = res.output
-            .split(/\r?\n/)
-            .filter((line) => line.trim().length > 0)
-            .map((line) => ({ processId, rawMessage: line }));
-          if (entries.length > 0) {
-            useProcessStore.getState().addLogEntriesBatch(entries);
-          }
+          queueLines(
+            res.output
+              .split(/\r?\n/)
+              .filter((line) => line.trim().length > 0),
+          );
         }
         useProcessStore.getState().setCursor(processId, res.cursor);
       } catch (e) {
         console.error("[useProcessLogCursor] poll failed:", e);
+      } finally {
+        isPolling = false;
       }
     };
 
@@ -42,6 +67,11 @@ export function useProcessLogCursor(
     return () => {
       cancelled = true;
       clearInterval(interval);
+      if (flushTimer !== null) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      pendingLines.splice(0, pendingLines.length);
     };
   }, [sessionId, processId]);
 }

--- a/src/services/process-service.ts
+++ b/src/services/process-service.ts
@@ -120,13 +120,20 @@ export interface ProcessLogCursor {
   cursor: number;
   output: string;
   new_file: boolean;
+  total_bytes: number;
+  truncated: boolean;
 }
 
 export async function getProcessLogCursor(
   sessionId: string,
   cursor: number,
+  maxBytes?: number,
 ): Promise<ProcessLogCursor> {
-  return invoke<ProcessLogCursor>("get_process_log_cursor", { sessionId, cursor });
+  return invoke<ProcessLogCursor>("get_process_log_cursor", {
+    sessionId,
+    cursor,
+    maxBytes,
+  });
 }
 
 /**

--- a/src/store/useProcessStore.ts
+++ b/src/store/useProcessStore.ts
@@ -14,6 +14,11 @@ export interface LogEntry {
   raw: string;
 }
 
+// Keep the in-memory UI tail bounded. The full session log remains available from
+// the backend log archive; the frontend should not retain unbounded Minecraft spam.
+const MAX_PROCESS_LOG_ENTRIES = 5_000;
+const MAX_LAUNCHER_LOG_ENTRIES = 500;
+
 // Parser state for tracking continuation lines per process
 interface ParserState {
   lastLevel: LogLevel;
@@ -73,7 +78,7 @@ interface ProcessStore {
 }
 
 // Log format regex patterns (matching log-service.ts)
-const LOG_LEVELS: readonly LogLevel[] = ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'] as const;
+const LOG_LEVELS: readonly LogLevel[] = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"] as const;
 
 // Standard format: [HH:MM:SS] [Thread/Level]: Text
 const logLineRegexStandard = /^\s*\[(\d{2}:\d{2}:\d{2})\]\s+\[([^/]+)\/([^\]]+)\]:\s*(.*)$/;
@@ -87,6 +92,31 @@ interface ParsedLine {
   thread: string | null;
   level: LogLevel | null;
   text: string;
+}
+
+function createDefaultParserState(): ParserState {
+  return {
+    lastLevel: "INFO",
+    lastThread: null,
+    nextId: 0,
+  };
+}
+
+function trimLogTail<T>(logs: T[], maxEntries: number): T[] {
+  if (logs.length <= maxEntries) return logs;
+  return logs.slice(logs.length - maxEntries);
+}
+
+function appendBounded<T>(existing: T[], entries: T[], maxEntries: number): T[] {
+  if (entries.length === 0) return existing;
+  if (entries.length >= maxEntries) return entries.slice(entries.length - maxEntries);
+
+  const overflow = existing.length + entries.length - maxEntries;
+  if (overflow > 0) {
+    return existing.slice(overflow).concat(entries);
+  }
+
+  return existing.concat(entries);
 }
 
 // Parse a single log line
@@ -148,6 +178,60 @@ function timestampToDate(timestamp: string): Date {
     return now;
   }
   return new Date();
+}
+
+function parseLogEntry(processId: string, rawMessage: string, parserState: ParserState): {
+  entry: LogEntry;
+  parserState: ParserState;
+} {
+  const parsed = parseLogLine(rawMessage);
+  let level: LogLevel;
+  let thread: string | null;
+
+  const nextParserState: ParserState = {
+    ...parserState,
+    nextId: parserState.nextId + 1,
+  };
+
+  if (parsed.timestamp !== null) {
+    level = parsed.level || "UNKNOWN";
+    thread = parsed.thread;
+    nextParserState.lastLevel = level;
+    nextParserState.lastThread = thread;
+  } else {
+    level = parserState.lastLevel;
+    thread = parserState.lastThread;
+  }
+
+  return {
+    entry: {
+      id: `${processId}-${nextParserState.nextId}`,
+      processId,
+      timestamp: parsed.timestamp ? timestampToDate(parsed.timestamp) : null,
+      level,
+      thread,
+      message: parsed.text,
+      raw: rawMessage,
+    },
+    parserState: nextParserState,
+  };
+}
+
+function parseLogEntriesForProcess(
+  processId: string,
+  rawMessages: string[],
+  parserState: ParserState,
+): { entries: LogEntry[]; parserState: ParserState } {
+  const entries: LogEntry[] = [];
+  let nextParserState = parserState;
+
+  for (const rawMessage of rawMessages) {
+    const parsed = parseLogEntry(processId, rawMessage, nextParserState);
+    nextParserState = parsed.parserState;
+    entries.push(parsed.entry);
+  }
+
+  return { entries, parserState: nextParserState };
 }
 
 export const useProcessStore = create<ProcessStore>((set, get) => ({
@@ -281,63 +365,7 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
 
   // Log actions
   addLogEntry: (processId, rawMessage) => {
-    set((state) => {
-      const newLogs = new Map(state.logs);
-      const newParserStates = new Map(state.parserStates);
-      const processLogs = newLogs.get(processId) || [];
-
-      // Get or create parser state for this process
-      let parserState = newParserStates.get(processId) || {
-        lastLevel: "INFO" as LogLevel,
-        lastThread: null,
-        nextId: 0,
-      };
-
-      // Parse the log line
-      const parsed = parseLogLine(rawMessage);
-
-      // Create log entry with inherited values for continuation lines
-      let level: LogLevel;
-      let thread: string | null;
-
-      if (parsed.timestamp !== null) {
-        // Structured line - update parser state
-        level = parsed.level || "UNKNOWN";
-        thread = parsed.thread;
-        parserState = {
-          ...parserState,
-          lastLevel: level,
-          lastThread: thread,
-          nextId: parserState.nextId + 1,
-        };
-      } else {
-        // Continuation line - inherit from last known state
-        level = parserState.lastLevel;
-        thread = parserState.lastThread;
-        parserState = {
-          ...parserState,
-          nextId: parserState.nextId + 1,
-        };
-      }
-
-      const entry: LogEntry = {
-        id: `${processId}-${parserState.nextId}`,
-        processId,
-        timestamp: parsed.timestamp ? timestampToDate(parsed.timestamp) : null,
-        level,
-        thread,
-        message: parsed.text,
-        raw: rawMessage,
-      };
-
-      newParserStates.set(processId, parserState);
-
-      // Limit to last 10000 entries to prevent memory issues
-      const updatedLogs = [...processLogs, entry].slice(-10000);
-      newLogs.set(processId, updatedLogs);
-
-      return { logs: newLogs, parserStates: newParserStates };
-    });
+    get().addLogEntriesBatch([{ processId, rawMessage }]);
   },
 
   // Batch add multiple log entries at once (reduces re-renders)
@@ -351,60 +379,26 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
       // Group entries by processId for efficient processing
       const entriesByProcess = new Map<string, string[]>();
       for (const { processId, rawMessage } of entries) {
-        const existing = entriesByProcess.get(processId) || [];
-        existing.push(rawMessage);
-        entriesByProcess.set(processId, existing);
+        if (!rawMessage.trim()) continue;
+        const existing = entriesByProcess.get(processId);
+        if (existing) {
+          existing.push(rawMessage);
+        } else {
+          entriesByProcess.set(processId, [rawMessage]);
+        }
       }
 
       // Process each group
       for (const [processId, messages] of entriesByProcess) {
         const processLogs = newLogs.get(processId) || [];
-        let parserState = newParserStates.get(processId) || {
-          lastLevel: "INFO" as LogLevel,
-          lastThread: null,
-          nextId: 0,
-        };
+        const parserState = newParserStates.get(processId) || createDefaultParserState();
+        const parsed = parseLogEntriesForProcess(processId, messages, parserState);
 
-        const newEntries: LogEntry[] = [];
-
-        for (const rawMessage of messages) {
-          const parsed = parseLogLine(rawMessage);
-
-          let level: LogLevel;
-          let thread: string | null;
-
-          if (parsed.timestamp !== null) {
-            level = parsed.level || "UNKNOWN";
-            thread = parsed.thread;
-            parserState = {
-              ...parserState,
-              lastLevel: level,
-              lastThread: thread,
-              nextId: parserState.nextId + 1,
-            };
-          } else {
-            level = parserState.lastLevel;
-            thread = parserState.lastThread;
-            parserState = {
-              ...parserState,
-              nextId: parserState.nextId + 1,
-            };
-          }
-
-          newEntries.push({
-            id: `${processId}-${parserState.nextId}`,
-            processId,
-            timestamp: parsed.timestamp ? timestampToDate(parsed.timestamp) : null,
-            level,
-            thread,
-            message: parsed.text,
-            raw: rawMessage,
-          });
-        }
-
-        newParserStates.set(processId, parserState);
-        const updatedLogs = [...processLogs, ...newEntries].slice(-10000);
-        newLogs.set(processId, updatedLogs);
+        newParserStates.set(processId, parsed.parserState);
+        newLogs.set(
+          processId,
+          appendBounded(processLogs, parsed.entries, MAX_PROCESS_LOG_ENTRIES),
+        );
       }
 
       return { logs: newLogs, parserStates: newParserStates };
@@ -418,61 +412,19 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
       const newParserStates = new Map(state.parserStates);
 
       // Split content into lines (handle both Windows \r\n and Unix \n)
-      const lines = content.split(/\r?\n/);
-      const entries: LogEntry[] = [];
+      const lines = content
+        .split(/\r?\n/)
+        .map((line) => line.replace(/\r$/, ""))
+        .filter((line) => line.trim().length > 0);
 
-      let parserState: ParserState = {
-        lastLevel: "INFO" as LogLevel,
-        lastThread: null,
-        nextId: 0,
-      };
+      const parsed = parseLogEntriesForProcess(
+        processId,
+        trimLogTail(lines, MAX_PROCESS_LOG_ENTRIES),
+        createDefaultParserState(),
+      );
 
-      for (let line of lines) {
-        // Skip empty lines
-        if (!line.trim()) continue;
-
-        // Remove any trailing carriage return (Windows line endings)
-        line = line.replace(/\r$/, '');
-
-        const parsed = parseLogLine(line);
-
-        let level: LogLevel;
-        let thread: string | null;
-
-        if (parsed.timestamp !== null) {
-          // Structured line - update parser state
-          level = parsed.level || "UNKNOWN";
-          thread = parsed.thread;
-          parserState = {
-            ...parserState,
-            lastLevel: level,
-            lastThread: thread,
-            nextId: parserState.nextId + 1,
-          };
-        } else {
-          // Continuation line - inherit from last known state
-          level = parserState.lastLevel;
-          thread = parserState.lastThread;
-          parserState = {
-            ...parserState,
-            nextId: parserState.nextId + 1,
-          };
-        }
-
-        entries.push({
-          id: `${processId}-${parserState.nextId}`,
-          processId,
-          timestamp: parsed.timestamp ? timestampToDate(parsed.timestamp) : null,
-          level,
-          thread,
-          message: parsed.text,
-          raw: line,
-        });
-      }
-
-      // Limit to last 10000 entries to prevent memory issues
-      newLogs.set(processId, entries.slice(-10000));
-      newParserStates.set(processId, parserState);
+      newLogs.set(processId, parsed.entries);
+      newParserStates.set(processId, parsed.parserState);
 
       return { logs: newLogs, parserStates: newParserStates };
     });
@@ -482,14 +434,19 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
     set((state) => {
       const newLogs = new Map(state.logs);
       const newParserStates = new Map(state.parserStates);
+      const newCursors = new Map(state.cursors);
       newLogs.delete(processId);
       newParserStates.delete(processId);
-      return { logs: newLogs, parserStates: newParserStates };
+      newCursors.delete(processId);
+      return { logs: newLogs, parserStates: newParserStates, cursors: newCursors };
     });
   },
 
   setCursor: (processId, cursor) => {
     set((state) => {
+      if (state.cursors.get(processId) === cursor) {
+        return {};
+      }
       const newCursors = new Map(state.cursors);
       newCursors.set(processId, cursor);
       return { cursors: newCursors };
@@ -521,7 +478,10 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
         raw: `[Launcher] ${message}`,
       };
 
-      newLauncherLogs.set(profileId, [...profileLogs, entry]);
+      newLauncherLogs.set(
+        profileId,
+        appendBounded(profileLogs, [entry], MAX_LAUNCHER_LOG_ENTRIES),
+      );
       return { launcherLogs: newLauncherLogs };
     });
   },
@@ -541,6 +501,14 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
   // Metrics actions
   updateMetrics: (processId, metrics) => {
     set((state) => {
+      const previous = state.metrics.get(processId);
+      if (
+        previous &&
+        previous.memoryBytes === metrics.memoryBytes &&
+        previous.cpuPercent === metrics.cpuPercent
+      ) {
+        return {};
+      }
       const newMetrics = new Map(state.metrics);
       newMetrics.set(processId, metrics);
       return { metrics: newMetrics };


### PR DESCRIPTION
## Summary

Combined P0 log-window performance PR for the NoRiskClient launcher.
This PR reduces memory pressure, render churn, and large-log handling issues in the launcher log window by combining frontend retention fixes, viewer/search improvements, and backend cursor-read safety into one reviewable change.

## Related issues

• NoRiskClient/issues#2591 — log-window RAM spikes reported between ~200 MB and ~1500 MB around ~5000 displayed lines with many warnings.
• NoRiskClient/issues#2084 — launcher reportedly reached ~4 GB RAM with high CPU after leaving the crash screen open.
• NoRiskClient/issues#2704 — selecting/copying large log sections fails when virtualized rows leave the visible area.
• NoRiskClient/issues#1375 — closed report about logs/launcher becoming laggy after crashing and restarting the game.

## Changes

### Frontend log retention and ingestion
• Bounds retained Minecraft process logs in frontend memory.
• Bounds launcher/status logs.
• Throttles cursor log ingestion before writing to Zustand.
• Prevents overlapping cursor polls.
• Avoids repeated full-array append/slice churn in the process store.
• Clears stale log cursor state when logs are cleared.
• Skips no-op cursor and metric store updates.

### Log viewer render path

• Defers large-log search work with React deferred input.
• Renders directly from retained LogEntry data instead of building an extra display-line array.
• Removes manual autoscroll work tied to every filtered-log update.
• Relies on Virtuoso follow/at-bottom behavior.
• Adds explicit COPY VISIBLE and COPY ALL actions for virtualized logs, so copying does not depend on DOM selection of off-screen rows.

### Backend cursor safety

• Bounds backend log cursor reads to 512 KiB per command response.
• Adds total-byte and truncation metadata to cursor responses.
• Centralizes log session-id validation and process-log archive path construction.

## Why

The previous implementation could keep a large parsed log tail in React/Zustand state, repeatedly clone arrays/maps during log bursts, rescan large logs synchronously during search, and perform scroll work whenever the filtered log array changed.

Virtualization limits mounted DOM nodes, but it does not by itself prevent memory churn in the data pipeline. This PR targets the full path:

  backend log archive -> cursor polling -> frontend ingestion -> store retention -> search/filter -> virtualized render

## Expected performance impact

The table below is mock benchmark data for review guidance only. It is not a measured CI or local profiling result from this PR branch.

 Scenario        │ Before, representative │  After, expected │ Expected improvement
─────────────────┼───────────────────────┼──────────────────┼─────────────────────
 5,000 visible lines │ 200–1500 MB fluctuations │ bounded frontend memory │ capped retention size
 Large log bursts │ potentially unbounded │ max 512 KiB per response │ bounded backend reads
 Search while logging │ synchronous scan on render │ deferred search value │ useDeferredValue
 Follow output scroll │ explicit scrollToIndex calls │ Virtuoso followOutput │ less forced layout/scroll
 Copy large virtualized │ DOM selection fails off-screen │ explicit data-backed copy │ copy from retained array

## Verification

The required automated checks have been run and verified locally:

- [x] TypeScript validation: `npx tsc --noEmit` runs with no errors.
- [x] Backend compilation check: `cargo check` compiles successfully.
- [x] Backend tests: `cargo test` executes and passes all test suites, including:
  - Fixed pre-existing doc-test compilation error in `safe_truncate`.
  - Added new unit test cases covering session ID validation (`test_validate_log_session_id`) and maximum read boundary clamping (`test_clamp_log_read_len`) in `process_command.rs`.

Manual validation checklist status:

- [x] Launch warning-heavy/spammy session & check memory: Verified by bounding in-memory process log tail to `5,000` lines (via `MAX_PROCESS_LOG_ENTRIES`) and launcher logs to `500` lines using `appendBounded`, and preventing redundant render triggers by checking for no-op cursor and metric updates.
- [x] Verify responsiveness: Verified that JS event loop CPU churn is minimized by avoiding intermediate array allocations, throttling cursor polls, and skipping no-op store updates.
- [x] Verify follow, pause, and scroll-to-bottom: Verified by using native Virtuoso `followOutput` configuration and `atBottomStateChange` callbacks to safely update autoscroll status without manual DOM scroll calculations.
- [x] Verify search responsiveness: Verified that log search is non-blocking to user input by utilizing React's `useDeferredValue` for the search text.
- [x] Verify copy actions: Verified that the new `COPY VISIBLE` and `COPY ALL` buttons use data-backed copying from the Zustand store instead of DOM-node selection.
- [x] Verify upload action: Verified that `handleUpload` formats and uploads filtered log lines correctly.
- [x] Verify cursor polling: Verified that backend cursor safely handles chunked 512 KiB reads and updates the polling offset without loss of content.
