### PR TITLE
feat(onboarding): add interactive launcher onboarding tour

### DIFF
--- a/src-tauri/src/state/config_state.rs
+++ b/src-tauri/src/state/config_state.rs
@@ -83,6 +83,9 @@ pub struct LauncherConfig {
     /// Pack rollout override: "auto" | "off" | "on"
     #[serde(default = "default_pack_rollout_override")]
     pub pack_rollout_override: String,
+    /// Version of the onboarding tutorial completed by the user.
+    #[serde(default)]
+    pub onboarding_completed_version: Option<String>,
 }
 
 fn default_config_version() -> u32 {
@@ -159,6 +162,7 @@ impl Default for LauncherConfig {
             cache_natives_extraction: default_cache_natives_extraction(),
             referral_state: None,
             pack_rollout_override: default_pack_rollout_override(),
+            onboarding_completed_version: None,
         }
     }
 }
@@ -396,6 +400,7 @@ impl ConfigManager {
                 && current.cache_natives_extraction == new_config.cache_natives_extraction
                 && current.referral_state == new_config.referral_state
                 && current.pack_rollout_override == new_config.pack_rollout_override
+                && current.onboarding_completed_version == new_config.onboarding_completed_version
             {
                 debug!("No config changes detected, skipping save");
                 false
@@ -506,6 +511,12 @@ impl ConfigManager {
                         current.use_browser_based_login, new_config.use_browser_based_login
                     );
                 }
+                if current.onboarding_completed_version != new_config.onboarding_completed_version {
+                    info!(
+                        "Changing onboarding completed version: {:?} -> {:?}",
+                        current.onboarding_completed_version, new_config.onboarding_completed_version
+                    );
+                }
 
                 // Update config while preserving version
                 *config = LauncherConfig {
@@ -529,6 +540,7 @@ impl ConfigManager {
                     cache_natives_extraction: new_config.cache_natives_extraction,
                     referral_state: new_config.referral_state.clone(),
                     pack_rollout_override: new_config.pack_rollout_override.clone(),
+                    onboarding_completed_version: new_config.onboarding_completed_version.clone(),
                 };
 
                 true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {
 } from "./types/events";
 import { GlobalCrashReportModal } from "./components/modals/GlobalCrashReportModal";
 import { TermsOfServiceModal, AnalyticsConsentBanner } from "./components/modals/TermsOfServiceModal";
+import { OnboardingModal } from "./components/modals/OnboardingModal";
 import { GlobalModalPortal } from "./components/ui/GlobalModalPortal";
 import { useCrashModalStore } from "./store/crash-modal-store";
 import { useThemeStore } from "./store/useThemeStore";
@@ -29,6 +30,7 @@ import { Modal } from "./components/ui/Modal";
 import { refreshNrcDataOnMount } from "./services/nrc-service";
 import {
   getLauncherConfig,
+  ONBOARDING_VERSION,
   setProfileGroupingPreference,
 } from "./services/launcher-config-service";
 import * as ConfigService from "./services/launcher-config-service";
@@ -82,6 +84,8 @@ export function App() {
 
   const [currentGroupingCriterion, setCurrentGroupingCriterion] =
       useState<string>("none");
+  const [onboardingCompletedVersion, setOnboardingCompletedVersion] =
+      useState<string | null | undefined>(undefined);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -384,6 +388,7 @@ export function App() {
           } else {
             setCurrentGroupingCriterion("none");
           }
+          setOnboardingCompletedVersion(config.onboarding_completed_version);
         })
         .catch((err) => {
           console.error(
@@ -391,7 +396,19 @@ export function App() {
               err,
           );
           setCurrentGroupingCriterion("none");
+          setOnboardingCompletedVersion(ONBOARDING_VERSION);
         });
+  }, []);
+
+  useEffect(() => {
+    const handleShowOnboarding = () => {
+      setOnboardingCompletedVersion(null);
+    };
+
+    window.addEventListener("norisk-show-onboarding", handleShowOnboarding);
+    return () => {
+      window.removeEventListener("norisk-show-onboarding", handleShowOnboarding);
+    };
   }, []);
 
   const handleProfileGroupingChange = async (newCriterion: string) => {
@@ -511,6 +528,16 @@ export function App() {
     }
   };
 
+  const handleOnboardingClose = async () => {
+    await ConfigService.completeOnboarding();
+    setOnboardingCompletedVersion(ONBOARDING_VERSION);
+  };
+
+  const shouldShowOnboarding =
+    hasAcceptedTermsOfService &&
+    onboardingCompletedVersion !== undefined &&
+    onboardingCompletedVersion !== ONBOARDING_VERSION;
+
   const profilesTabContext: ProfilesTabContext = {
     currentGroupingCriterion,
     onGroupingChange: handleProfileGroupingChange,
@@ -532,6 +559,11 @@ export function App() {
         <AppLayout activeTab={activeTab} onNavChange={handleNavChange}>
           <Outlet context={profilesTabContext} />
         </AppLayout>
+        <OnboardingModal
+          isOpen={shouldShowOnboarding}
+          onClose={handleOnboardingClose}
+          onNavigate={handleNavChange}
+        />
         {shouldShowAnalyticsBanner() && (
           <AnalyticsConsentBanner
             onAccept={handleAnalyticsAccept}

--- a/src/components/modals/OnboardingModal.tsx
+++ b/src/components/modals/OnboardingModal.tsx
@@ -1,0 +1,413 @@
+import { useEffect, useMemo, useState } from "react";
+import { Icon } from "@iconify/react";
+import { useTranslation } from "react-i18next";
+import { toast } from "react-hot-toast";
+import { Modal } from "../ui/Modal";
+import { Button } from "../ui/buttons/Button";
+import { useThemeStore } from "../../store/useThemeStore";
+
+interface OnboardingModalProps {
+  isOpen: boolean;
+  onClose: () => Promise<void> | void;
+  onNavigate?: (tabId: string) => void;
+}
+
+interface OnboardingStep {
+  key: string;
+  icon: string;
+  accentClassName: string;
+  navTarget?: string;
+  label: string;
+  title: string;
+  subtitle: string;
+  description: string;
+  tips: [string, string];
+}
+
+const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    key: "welcome",
+    icon: "solar:compass-bold",
+    accentClassName: "text-sky-300",
+    label: "Welcome",
+    title: "welcome",
+    subtitle: "A short tour of the launcher",
+    description:
+      "NoRisk Launcher is organized around the left navigation. You can start playing immediately, then come back to profiles, mods, cosmetics, and settings when you need them.",
+    tips: [
+      "Use the icons on the left to switch between the main launcher areas.",
+      "You can close this tour now and replay it later from Settings.",
+    ],
+  },
+  {
+    key: "play",
+    icon: "solar:play-bold",
+    accentClassName: "text-emerald-300",
+    navTarget: "play",
+    label: "Play",
+    title: "play",
+    subtitle: "Start Minecraft from the main screen",
+    description:
+      "The Play screen keeps launching focused: choose the profile/version you want, check the selected account, then start the game.",
+    tips: [
+      "If no profile is selected, the launcher picks the first available profile.",
+      "News and referral information stay on the side so launch controls remain easy to find.",
+    ],
+  },
+  {
+    key: "profiles",
+    icon: "solar:user-id-bold",
+    accentClassName: "text-violet-300",
+    navTarget: "profiles",
+    label: "Profiles",
+    title: "profiles",
+    subtitle: "Create and manage installations",
+    description:
+      "Profiles are separate Minecraft setups. Use them for different versions, mod loaders, modpacks, worlds, and launch settings.",
+    tips: [
+      "Create custom profiles when you want a setup that differs from the standard NoRisk profiles.",
+      "Profile detail pages are where you manage worlds, screenshots, logs, and local content.",
+    ],
+  },
+  {
+    key: "mods",
+    icon: "solar:widget-bold",
+    accentClassName: "text-amber-300",
+    navTarget: "mods",
+    label: "Mods",
+    title: "mods",
+    subtitle: "Browse and install content",
+    description:
+      "The Mods area lets you search online content and add it to a profile without manually moving files around.",
+    tips: [
+      "Choose the target profile before installing so content lands in the right place.",
+      "Profile content tabs let you enable, disable, update, or remove installed items later.",
+    ],
+  },
+  {
+    key: "cosmetics",
+    icon: "solar:emoji-funny-circle-bold",
+    accentClassName: "text-pink-300",
+    navTarget: "skins",
+    label: "Cosmetics",
+    title: "cosmetics",
+    subtitle: "Manage skins and capes",
+    description:
+      "Skins and capes live in their own areas. Sign in first, then upload, preview, apply, or manage your cosmetic items.",
+    tips: [
+      "Skin tools support uploads and imports by username, UUID, or URL.",
+      "Cape uploads can be previewed before submission. Some capes may need review.",
+    ],
+  },
+  {
+    key: "settings",
+    icon: "solar:settings-bold",
+    accentClassName: "text-cyan-300",
+    navTarget: "settings",
+    label: "Settings",
+    title: "settings",
+    subtitle: "Tune launcher behavior",
+    description:
+      "Settings contains language, appearance, update behavior, analytics preference, data location, and advanced launch options.",
+    tips: [
+      "Most general launcher preferences save automatically after a short delay.",
+      "Advanced hooks run system commands, so only enable them when you know what they do.",
+    ],
+  },
+];
+
+export function OnboardingModal({
+  isOpen,
+  onClose,
+  onNavigate,
+}: OnboardingModalProps) {
+  const { t } = useTranslation();
+  const accentColor = useThemeStore((state) => state.accentColor);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [isClosing, setIsClosing] = useState(false);
+  const [isDocked, setIsDocked] = useState(false);
+
+  const currentStep = ONBOARDING_STEPS[currentStepIndex];
+  const isFirstStep = currentStepIndex === 0;
+  const isLastStep = currentStepIndex === ONBOARDING_STEPS.length - 1;
+  const progressPercent = useMemo(
+    () => ((currentStepIndex + 1) / ONBOARDING_STEPS.length) * 100,
+    [currentStepIndex],
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsClosing(false);
+      setIsDocked(false);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const finish = async () => {
+    if (isClosing) return;
+    setIsClosing(true);
+    try {
+      await onClose();
+      toast.success(
+        t("onboarding.toast.completed", {
+          defaultValue: "Onboarding completed. You can replay it from Settings.",
+        }),
+      );
+    } catch (error) {
+      console.error("[OnboardingModal] Failed to save onboarding state:", error);
+      toast.error(
+        t("onboarding.toast.failed", {
+          defaultValue: "Failed to save onboarding state. Please try again.",
+        }),
+      );
+      setIsClosing(false);
+    }
+  };
+
+  const goToStep = (index: number) => {
+    setCurrentStepIndex(Math.max(0, Math.min(index, ONBOARDING_STEPS.length - 1)));
+  };
+
+  const handleNavigate = () => {
+    if (currentStep.navTarget && onNavigate) {
+      onNavigate(currentStep.navTarget);
+      setIsDocked(true);
+    }
+  };
+
+  if (isDocked) {
+    return (
+      <div className="fixed left-1/2 top-4 z-[1000] w-[min(720px,calc(100vw-2rem))] -translate-x-1/2">
+        <div
+          className="border border-b-2 bg-black/75 px-4 py-3 shadow-2xl backdrop-blur-md"
+          style={{
+            borderColor: `${accentColor.value}80`,
+            borderBottomColor: accentColor.value,
+          }}
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <Icon
+                icon={currentStep.icon}
+                className={`h-7 w-7 flex-shrink-0 ${currentStep.accentClassName}`}
+              />
+              <div className="min-w-0">
+                <div className="font-minecraft text-2xl lowercase text-white">
+                  {t("onboarding.docked_title", {
+                    section: t(`onboarding.steps.${currentStep.key}.label`, {
+                      defaultValue: currentStep.label,
+                    }),
+                    defaultValue: "{{section}} is open",
+                  })}
+                </div>
+                <div className="truncate font-minecraft-ten text-sm text-white/60">
+                  {t("onboarding.docked_description", {
+                    defaultValue: "The tour is docked while you look around.",
+                  })}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={finish}
+                disabled={isClosing}
+                icon={<Icon icon="solar:check-circle-bold" className="w-4 h-4" />}
+              >
+                {t("onboarding.button.finish", { defaultValue: "finish" })}
+              </Button>
+              <Button
+                variant="flat"
+                size="xs"
+                onClick={() => setIsDocked(false)}
+                disabled={isClosing}
+                icon={<Icon icon="solar:full-screen-bold" className="w-4 h-4" />}
+              >
+                {t("onboarding.button.resume", { defaultValue: "resume" })}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const footer = (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={finish}
+        disabled={isClosing}
+        icon={<Icon icon="solar:close-circle-bold" className="w-5 h-5" />}
+      >
+        {t("onboarding.button.skip", { defaultValue: "skip" })}
+      </Button>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => goToStep(currentStepIndex - 1)}
+          disabled={isFirstStep || isClosing}
+          icon={<Icon icon="solar:alt-arrow-left-bold" className="w-5 h-5" />}
+        >
+          {t("onboarding.button.back", { defaultValue: "back" })}
+        </Button>
+        <Button
+          variant="default"
+          size="sm"
+          onClick={isLastStep ? finish : () => goToStep(currentStepIndex + 1)}
+          disabled={isClosing}
+          icon={
+            <Icon
+              icon={isLastStep ? "solar:check-circle-bold" : "solar:alt-arrow-right-bold"}
+              className="w-5 h-5"
+            />
+          }
+          iconPosition="right"
+        >
+          {isLastStep
+            ? t("onboarding.button.finish", { defaultValue: "finish" })
+            : t("onboarding.button.next", { defaultValue: "next" })}
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <Modal
+      title={t("onboarding.title", { defaultValue: "Launcher Onboarding" })}
+      titleIcon={<Icon icon="solar:compass-bold" className="w-7 h-7 text-white" />}
+      titleSubtitle={
+        <span className="font-minecraft-ten text-sm text-white/60">
+          {t("onboarding.step_count", {
+            current: currentStepIndex + 1,
+            total: ONBOARDING_STEPS.length,
+            defaultValue: "Step {{current}} of {{total}}",
+          })}
+        </span>
+      }
+      onClose={finish}
+      closeOnClickOutside={false}
+      width="xl"
+      footer={footer}
+      contentClassName="bg-black/35"
+    >
+      <div className="p-6 space-y-6 text-white">
+        <div className="h-2 overflow-hidden rounded bg-white/10">
+          <div
+            className="h-full transition-all duration-300"
+            style={{
+              width: `${progressPercent}%`,
+              backgroundColor: accentColor.value,
+            }}
+          />
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)]">
+          <div className="space-y-2">
+            {ONBOARDING_STEPS.map((step, index) => {
+              const isActive = index === currentStepIndex;
+              return (
+                <button
+                  key={step.key}
+                  type="button"
+                  onClick={() => goToStep(index)}
+                  className="flex min-h-[48px] w-full items-center gap-3 border border-white/10 bg-white/[0.03] px-3 py-2 text-left transition-colors hover:bg-white/10"
+                  style={{
+                    borderColor: isActive ? `${accentColor.value}90` : undefined,
+                    backgroundColor: isActive ? `${accentColor.value}22` : undefined,
+                  }}
+                >
+                  <Icon icon={step.icon} className={`h-6 w-6 ${step.accentClassName}`} />
+                  <span className="font-minecraft-ten text-base text-white/85">
+                    {t(`onboarding.steps.${step.key}.label`, {
+                      defaultValue: step.label,
+                    })}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="min-h-[360px] border border-white/10 bg-black/25 p-6">
+            <div className="flex h-full flex-col">
+              <div className="mb-6 flex items-center gap-4">
+                <div
+                  className="flex h-16 w-16 items-center justify-center border border-white/15 bg-black/30"
+                  style={{ borderColor: `${accentColor.value}70` }}
+                >
+                  <Icon
+                    icon={currentStep.icon}
+                    className={`h-10 w-10 ${currentStep.accentClassName}`}
+                  />
+                </div>
+                <div className="min-w-0">
+                  <h3 className="font-minecraft text-4xl lowercase text-white">
+                    {t(`onboarding.steps.${currentStep.key}.title`, {
+                      defaultValue: currentStep.title,
+                    })}
+                  </h3>
+                  <p className="mt-1 font-minecraft-ten text-base text-white/60">
+                    {t(`onboarding.steps.${currentStep.key}.subtitle`, {
+                      defaultValue: currentStep.subtitle,
+                    })}
+                  </p>
+                </div>
+              </div>
+
+              <p className="font-minecraft-ten text-lg leading-relaxed text-white/80">
+                {t(`onboarding.steps.${currentStep.key}.description`, {
+                  defaultValue: currentStep.description,
+                })}
+              </p>
+
+              <div className="mt-6 grid gap-3 md:grid-cols-2">
+                {[0, 1].map((tipIndex) => (
+                  <div
+                    key={tipIndex}
+                    className="min-h-[92px] border border-white/10 bg-white/[0.04] p-4"
+                  >
+                    <div className="mb-2 flex items-center gap-2">
+                      <Icon
+                        icon="solar:check-circle-bold"
+                        className="h-5 w-5 text-emerald-300"
+                      />
+                      <span className="font-minecraft-ten text-sm uppercase text-white/50">
+                        {t("onboarding.tip_label", { defaultValue: "Tip" })}
+                      </span>
+                    </div>
+                    <p className="font-minecraft-ten text-base leading-relaxed text-white/75">
+                      {t(`onboarding.steps.${currentStep.key}.tips.${tipIndex}`, {
+                        defaultValue: currentStep.tips[tipIndex],
+                      })}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-auto pt-6">
+                {currentStep.navTarget && (
+                  <Button
+                    variant="flat"
+                    size="sm"
+                    onClick={handleNavigate}
+                    icon={<Icon icon="solar:map-arrow-right-bold" className="w-5 h-5" />}
+                  >
+                    {t("onboarding.button.open_section", {
+                      defaultValue: "open section",
+                    })}
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/modals/OnboardingModal.tsx
+++ b/src/components/modals/OnboardingModal.tsx
@@ -5,6 +5,7 @@ import { toast } from "react-hot-toast";
 import { Modal } from "../ui/Modal";
 import { Button } from "../ui/buttons/Button";
 import { useThemeStore } from "../../store/useThemeStore";
+import { Logo } from "../ui/Logo";
 
 interface OnboardingModalProps {
   isOpen: boolean;
@@ -336,74 +337,135 @@ export function OnboardingModal({
 
           <div className="min-h-[360px] border border-white/10 bg-black/25 p-6">
             <div className="flex h-full flex-col">
-              <div className="mb-6 flex items-center gap-4">
-                <div
-                  className="flex h-16 w-16 items-center justify-center border border-white/15 bg-black/30"
-                  style={{ borderColor: `${accentColor.value}70` }}
-                >
-                  <Icon
-                    icon={currentStep.icon}
-                    className={`h-10 w-10 ${currentStep.accentClassName}`}
-                  />
-                </div>
-                <div className="min-w-0">
-                  <h3 className="font-minecraft text-4xl lowercase text-white">
-                    {t(`onboarding.steps.${currentStep.key}.title`, {
-                      defaultValue: currentStep.title,
-                    })}
+              {currentStep.key === "welcome" ? (
+                <div className="flex h-full flex-col items-center justify-center text-center py-6">
+                  {/* Glowing Logo Container */}
+                  <div className="relative mb-6 group">
+                    <div
+                      className="absolute -inset-4 rounded-full opacity-20 blur-xl transition-all duration-1000 group-hover:opacity-45"
+                      style={{
+                        background: `radial-gradient(circle, ${accentColor.value} 0%, transparent 70%)`,
+                      }}
+                    />
+                    <Logo
+                      size="lg"
+                      className="relative transform hover:scale-105 transition-transform duration-300 mx-auto"
+                    />
+                  </div>
+
+                  <h3 className="font-minecraft text-5xl tracking-wide text-white lowercase">
+                    norisk client
                   </h3>
-                  <p className="mt-1 font-minecraft-ten text-base text-white/60">
+                  <p className="mt-2 font-minecraft-ten text-base text-white/50 uppercase tracking-widest">
                     {t(`onboarding.steps.${currentStep.key}.subtitle`, {
                       defaultValue: currentStep.subtitle,
                     })}
                   </p>
-                </div>
-              </div>
 
-              <p className="font-minecraft-ten text-lg leading-relaxed text-white/80">
-                {t(`onboarding.steps.${currentStep.key}.description`, {
-                  defaultValue: currentStep.description,
-                })}
-              </p>
-
-              <div className="mt-6 grid gap-3 md:grid-cols-2">
-                {[0, 1].map((tipIndex) => (
-                  <div
-                    key={tipIndex}
-                    className="min-h-[92px] border border-white/10 bg-white/[0.04] p-4"
-                  >
-                    <div className="mb-2 flex items-center gap-2">
-                      <Icon
-                        icon="solar:check-circle-bold"
-                        className="h-5 w-5 text-emerald-300"
-                      />
-                      <span className="font-minecraft-ten text-sm uppercase text-white/50">
-                        {t("onboarding.tip_label", { defaultValue: "Tip" })}
-                      </span>
-                    </div>
-                    <p className="font-minecraft-ten text-base leading-relaxed text-white/75">
-                      {t(`onboarding.steps.${currentStep.key}.tips.${tipIndex}`, {
-                        defaultValue: currentStep.tips[tipIndex],
+                  <div className="mt-6 max-w-lg border border-white/10 bg-white/[0.02] p-5 backdrop-blur-sm">
+                    <p className="font-minecraft-ten text-lg leading-relaxed text-white/80">
+                      {t(`onboarding.steps.${currentStep.key}.description`, {
+                        defaultValue: currentStep.description,
                       })}
                     </p>
                   </div>
-                ))}
-              </div>
 
-              <div className="mt-auto pt-6">
-                {currentStep.navTarget && (
-                  <Button
-                    variant="flat"
-                    size="sm"
-                    onClick={handleNavigate}
-                    icon={<Icon icon="solar:map-arrow-right-bold" className="w-5 h-5" />}
-                  >
-                    {t("onboarding.button.open_section", {
-                      defaultValue: "open section",
+                  <div className="mt-8 grid gap-4 md:grid-cols-2 w-full">
+                    {[0, 1].map((tipIndex) => (
+                      <div
+                        key={tipIndex}
+                        className="border border-white/10 bg-white/[0.04] p-4 text-left flex items-start gap-3 transition-colors hover:bg-white/[0.06]"
+                      >
+                        <Icon
+                          icon="solar:check-circle-bold"
+                          className="h-5 w-5 text-emerald-300 mt-0.5 flex-shrink-0"
+                        />
+                        <div>
+                          <span className="block font-minecraft-ten text-[11px] uppercase text-white/40 mb-1">
+                            {t("onboarding.tip_label", { defaultValue: "Tip" })}
+                          </span>
+                          <p className="font-minecraft-ten text-sm leading-relaxed text-white/75">
+                            {t(`onboarding.steps.${currentStep.key}.tips.${tipIndex}`, {
+                              defaultValue: currentStep.tips[tipIndex],
+                            })}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="mb-6 flex items-center gap-4">
+                    <div
+                      className="flex h-16 w-16 items-center justify-center border border-white/15 bg-black/30"
+                      style={{ borderColor: `${accentColor.value}70` }}
+                    >
+                      <Icon
+                        icon={currentStep.icon}
+                        className={`h-10 w-10 ${currentStep.accentClassName}`}
+                      />
+                    </div>
+                    <div className="min-w-0">
+                      <h3 className="font-minecraft text-4xl lowercase text-white">
+                        {t(`onboarding.steps.${currentStep.key}.title`, {
+                          defaultValue: currentStep.title,
+                        })}
+                      </h3>
+                      <p className="mt-1 font-minecraft-ten text-base text-white/60">
+                        {t(`onboarding.steps.${currentStep.key}.subtitle`, {
+                          defaultValue: currentStep.subtitle,
+                        })}
+                      </p>
+                    </div>
+                  </div>
+
+                  <p className="font-minecraft-ten text-lg leading-relaxed text-white/80">
+                    {t(`onboarding.steps.${currentStep.key}.description`, {
+                      defaultValue: currentStep.description,
                     })}
-                  </Button>
-                )}
-              </div>
+                  </p>
+
+                  <div className="mt-6 grid gap-3 md:grid-cols-2">
+                    {[0, 1].map((tipIndex) => (
+                      <div
+                        key={tipIndex}
+                        className="min-h-[92px] border border-white/10 bg-white/[0.04] p-4"
+                      >
+                        <div className="mb-2 flex items-center gap-2">
+                          <Icon
+                            icon="solar:check-circle-bold"
+                            className="h-5 w-5 text-emerald-300"
+                          />
+                          <span className="font-minecraft-ten text-sm uppercase text-white/50">
+                            {t("onboarding.tip_label", { defaultValue: "Tip" })}
+                          </span>
+                        </div>
+                        <p className="font-minecraft-ten text-base leading-relaxed text-white/75">
+                          {t(`onboarding.steps.${currentStep.key}.tips.${tipIndex}`, {
+                            defaultValue: currentStep.tips[tipIndex],
+                          })}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="mt-auto pt-6">
+                    {currentStep.navTarget && (
+                      <Button
+                        variant="flat"
+                        size="sm"
+                        onClick={handleNavigate}
+                        icon={<Icon icon="solar:map-arrow-right-bold" className="w-5 h-5" />}
+                      >
+                        {t("onboarding.button.open_section", {
+                          defaultValue: "open section",
+                        })}
+                      </Button>
+                    )}
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/modals/OnboardingModal.tsx
+++ b/src/components/modals/OnboardingModal.tsx
@@ -138,6 +138,7 @@ export function OnboardingModal({
 
   useEffect(() => {
     if (isOpen) {
+      setCurrentStepIndex(0);
       setIsClosing(false);
       setIsDocked(false);
     }
@@ -339,7 +340,6 @@ export function OnboardingModal({
             <div className="flex h-full flex-col">
               {currentStep.key === "welcome" ? (
                 <div className="flex h-full flex-col items-center justify-center text-center py-2 space-y-4">
-                  {/* Glowing Logo Container */}
                   <div className="relative group">
                     <div
                       className="absolute -inset-3 rounded-full opacity-20 blur-lg transition-all duration-1000 group-hover:opacity-40"

--- a/src/components/modals/OnboardingModal.tsx
+++ b/src/components/modals/OnboardingModal.tsx
@@ -338,53 +338,55 @@ export function OnboardingModal({
           <div className="min-h-[360px] border border-white/10 bg-black/25 p-6">
             <div className="flex h-full flex-col">
               {currentStep.key === "welcome" ? (
-                <div className="flex h-full flex-col items-center justify-center text-center py-6">
+                <div className="flex h-full flex-col items-center justify-center text-center py-2 space-y-4">
                   {/* Glowing Logo Container */}
-                  <div className="relative mb-6 group">
+                  <div className="relative group">
                     <div
-                      className="absolute -inset-4 rounded-full opacity-20 blur-xl transition-all duration-1000 group-hover:opacity-45"
+                      className="absolute -inset-3 rounded-full opacity-20 blur-lg transition-all duration-1000 group-hover:opacity-40"
                       style={{
                         background: `radial-gradient(circle, ${accentColor.value} 0%, transparent 70%)`,
                       }}
                     />
                     <Logo
-                      size="lg"
+                      size="md"
                       className="relative transform hover:scale-105 transition-transform duration-300 mx-auto"
                     />
                   </div>
 
-                  <h3 className="font-minecraft text-5xl tracking-wide text-white lowercase">
-                    norisk client
-                  </h3>
-                  <p className="mt-2 font-minecraft-ten text-base text-white/50 uppercase tracking-widest">
-                    {t(`onboarding.steps.${currentStep.key}.subtitle`, {
-                      defaultValue: currentStep.subtitle,
-                    })}
-                  </p>
+                  <div>
+                    <h3 className="font-minecraft text-4xl tracking-wide text-white lowercase">
+                      norisk client
+                    </h3>
+                    <p className="mt-0.5 font-minecraft-ten text-[13px] text-white/50 uppercase tracking-widest">
+                      {t(`onboarding.steps.${currentStep.key}.subtitle`, {
+                        defaultValue: currentStep.subtitle,
+                      })}
+                    </p>
+                  </div>
 
-                  <div className="mt-6 max-w-lg border border-white/10 bg-white/[0.02] p-5 backdrop-blur-sm">
-                    <p className="font-minecraft-ten text-lg leading-relaxed text-white/80">
+                  <div className="max-w-lg border border-white/10 bg-white/[0.02] p-3.5 backdrop-blur-sm">
+                    <p className="font-minecraft-ten text-sm leading-relaxed text-white/80">
                       {t(`onboarding.steps.${currentStep.key}.description`, {
                         defaultValue: currentStep.description,
                       })}
                     </p>
                   </div>
 
-                  <div className="mt-8 grid gap-4 md:grid-cols-2 w-full">
+                  <div className="grid gap-3 md:grid-cols-2 w-full">
                     {[0, 1].map((tipIndex) => (
                       <div
                         key={tipIndex}
-                        className="border border-white/10 bg-white/[0.04] p-4 text-left flex items-start gap-3 transition-colors hover:bg-white/[0.06]"
+                        className="border border-white/10 bg-white/[0.04] p-3 text-left flex items-start gap-2.5 transition-colors hover:bg-white/[0.06]"
                       >
                         <Icon
                           icon="solar:check-circle-bold"
-                          className="h-5 w-5 text-emerald-300 mt-0.5 flex-shrink-0"
+                          className="h-4 w-4 text-emerald-300 mt-0.5 flex-shrink-0"
                         />
                         <div>
-                          <span className="block font-minecraft-ten text-[11px] uppercase text-white/40 mb-1">
+                          <span className="block font-minecraft-ten text-[10px] uppercase text-white/40">
                             {t("onboarding.tip_label", { defaultValue: "Tip" })}
                           </span>
-                          <p className="font-minecraft-ten text-sm leading-relaxed text-white/75">
+                          <p className="font-minecraft-ten text-xs leading-normal text-white/70">
                             {t(`onboarding.steps.${currentStep.key}.tips.${tipIndex}`, {
                               defaultValue: currentStep.tips[tipIndex],
                             })}

--- a/src/components/tabs/SettingsTab.tsx
+++ b/src/components/tabs/SettingsTab.tsx
@@ -288,6 +288,20 @@ export function SettingsTab() {
     }
   };
 
+  const handleShowOnboarding = async () => {
+    try {
+      await ConfigService.resetOnboarding();
+      window.dispatchEvent(new CustomEvent("norisk-show-onboarding"));
+    } catch (err) {
+      console.error("Failed to reopen onboarding:", err);
+      toast.error(
+        t("onboarding.toast.failed", {
+          defaultValue: "Failed to save onboarding state. Please try again.",
+        }),
+      );
+    }
+  };
+
   const hasChanges =
     config &&
     tempConfig &&
@@ -320,6 +334,31 @@ export function SettingsTab() {
             size="sm"
             variant="flat"
           />
+        </div>
+      </div>
+
+      <div className="border border-white/10 bg-black/20 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex min-w-0 flex-1 items-start gap-3">
+            <Icon icon="solar:compass-bold" className="mt-1 h-6 w-6 flex-shrink-0 text-white" />
+            <div className="min-w-0">
+              <h3 className="text-3xl font-minecraft text-white">
+                {t("settings.onboarding.title")}
+              </h3>
+              <p className="mt-2 text-base text-white/70 font-minecraft-ten">
+                {t("settings.onboarding.description")}
+              </p>
+            </div>
+          </div>
+          <Button
+            variant="flat"
+            size="sm"
+            onClick={handleShowOnboarding}
+            icon={<Icon icon="solar:map-arrow-right-bold" className="w-5 h-5" />}
+            disabled={saving}
+          >
+            {t("settings.onboarding.button")}
+          </Button>
         </div>
       </div>
 

--- a/src/i18n/translations/de.json
+++ b/src/i18n/translations/de.json
@@ -18,6 +18,10 @@
   "settings.language": "Sprache",
   "settings.language.description": "Wähle die Anzeigesprache für den Launcher",
 
+  "settings.onboarding.title": "Einführung",
+  "settings.onboarding.description": "Starte die Launcher-Einführung jederzeit erneut, wenn du eine kurze Orientierung möchtest.",
+  "settings.onboarding.button": "Einführung anzeigen",
+
   "settings.accent_color.title": "Akzentfarbe",
   "settings.accent_color.description": "Wähle deine bevorzugte Akzentfarbe für den Launcher",
   "settings.accent_color.disabled_theme": "(Deaktiviert während ein Theme aktiv ist)",

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -18,6 +18,10 @@
   "settings.language": "Language",
   "settings.language.description": "Choose the display language for the launcher",
 
+  "settings.onboarding.title": "Onboarding",
+  "settings.onboarding.description": "Replay the launcher introduction whenever you want a quick orientation.",
+  "settings.onboarding.button": "Show onboarding",
+
   "settings.accent_color.title": "Accent Color",
   "settings.accent_color.description": "Choose your preferred accent color for the launcher",
   "settings.accent_color.disabled_theme": "(Disabled while a theme is active)",

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -14,6 +14,10 @@
   "settings.tabs.debug": "Depuración",
   "settings.language": "Idioma",
   "settings.language.description": "Elige el idioma de visualización del launcher",
+
+  "settings.onboarding.title": "Onboarding",
+  "settings.onboarding.description": "Replay the launcher introduction whenever you want a quick orientation.",
+  "settings.onboarding.button": "Show onboarding",
   "settings.accent_color.title": "Color de Acento",
   "settings.accent_color.description": "Elige tu color de acento preferido para el launcher",
   "settings.accent_color.disabled_theme": "(Desactivado mientras un tema está activo)",

--- a/src/i18n/translations/fr.json
+++ b/src/i18n/translations/fr.json
@@ -14,6 +14,10 @@
   "settings.tabs.debug": "Débogage",
   "settings.language": "Langue",
   "settings.language.description": "Choisissez la langue d'affichage du launcher",
+
+  "settings.onboarding.title": "Onboarding",
+  "settings.onboarding.description": "Replay the launcher introduction whenever you want a quick orientation.",
+  "settings.onboarding.button": "Show onboarding",
   "settings.accent_color.title": "Couleur d'Accentuation",
   "settings.accent_color.description": "Choisissez votre couleur d'accentuation préférée pour le launcher",
   "settings.accent_color.disabled_theme": "(Désactivé quand un thème est actif)",

--- a/src/i18n/translations/hi.json
+++ b/src/i18n/translations/hi.json
@@ -14,6 +14,10 @@
   "settings.tabs.debug": "डीबग",
   "settings.language": "भाषा",
   "settings.language.description": "लॉन्चर के लिए प्रदर्शन भाषा चुनें",
+
+  "settings.onboarding.title": "Onboarding",
+  "settings.onboarding.description": "Replay the launcher introduction whenever you want a quick orientation.",
+  "settings.onboarding.button": "Show onboarding",
   "settings.accent_color.title": "एक्सेंट रंग",
   "settings.accent_color.description": "लॉन्चर के लिए अपना पसंदीदा एक्सेंट रंग चुनें",
   "settings.accent_color.disabled_theme": "(थीम सक्रिय रहने पर अक्षम)",

--- a/src/i18n/translations/it.json
+++ b/src/i18n/translations/it.json
@@ -14,6 +14,10 @@
   "settings.tabs.debug": "Debug",
   "settings.language": "Lingua",
   "settings.language.description": "Scegli la lingua di visualizzazione del launcher",
+
+  "settings.onboarding.title": "Onboarding",
+  "settings.onboarding.description": "Replay the launcher introduction whenever you want a quick orientation.",
+  "settings.onboarding.button": "Show onboarding",
   "settings.accent_color.title": "Colore accento",
   "settings.accent_color.description": "Scegli il colore accento preferito per il launcher",
   "settings.accent_color.disabled_theme": "(Disabilitato mentre un tema è attivo)",

--- a/src/i18n/translations/pl.json
+++ b/src/i18n/translations/pl.json
@@ -14,6 +14,10 @@
   "settings.tabs.debug": "Debugowanie",
   "settings.language": "Język",
   "settings.language.description": "Wybierz język wyświetlania launchera",
+
+  "settings.onboarding.title": "Onboarding",
+  "settings.onboarding.description": "Replay the launcher introduction whenever you want a quick orientation.",
+  "settings.onboarding.button": "Show onboarding",
   "settings.accent_color.title": "Kolor akcentu",
   "settings.accent_color.description": "Wybierz preferowany kolor akcentu dla launchera",
   "settings.accent_color.disabled_theme": "(Wyłączone przy aktywnym motywie)",

--- a/src/i18n/translations/pt.json
+++ b/src/i18n/translations/pt.json
@@ -14,6 +14,10 @@
   "settings.tabs.debug": "Depuração",
   "settings.language": "Idioma",
   "settings.language.description": "Escolha o idioma de exibição do launcher",
+
+  "settings.onboarding.title": "Onboarding",
+  "settings.onboarding.description": "Replay the launcher introduction whenever you want a quick orientation.",
+  "settings.onboarding.button": "Show onboarding",
   "settings.accent_color.title": "Cor de Destaque",
   "settings.accent_color.description": "Escolha sua cor de destaque preferida para o launcher",
   "settings.accent_color.disabled_theme": "(Desativado enquanto um tema está ativo)",

--- a/src/i18n/translations/ru.json
+++ b/src/i18n/translations/ru.json
@@ -14,6 +14,10 @@
   "settings.tabs.debug": "Отладка",
   "settings.language": "Язык",
   "settings.language.description": "Выберите язык отображения лаунчера",
+
+  "settings.onboarding.title": "Onboarding",
+  "settings.onboarding.description": "Replay the launcher introduction whenever you want a quick orientation.",
+  "settings.onboarding.button": "Show onboarding",
   "settings.accent_color.title": "Цвет акцента",
   "settings.accent_color.description": "Выберите предпочитаемый цвет акцента для лаунчера",
   "settings.accent_color.disabled_theme": "(Отключено при активной теме)",

--- a/src/i18n/translations/tr.json
+++ b/src/i18n/translations/tr.json
@@ -14,6 +14,10 @@
   "settings.tabs.debug": "Hata Ayıklama",
   "settings.language": "Dil",
   "settings.language.description": "Başlatıcı için görüntüleme dilini seçin",
+
+  "settings.onboarding.title": "Onboarding",
+  "settings.onboarding.description": "Replay the launcher introduction whenever you want a quick orientation.",
+  "settings.onboarding.button": "Show onboarding",
   "settings.accent_color.title": "Vurgu Rengi",
   "settings.accent_color.description": "Başlatıcı için tercih ettiğiniz vurgu rengini seçin",
   "settings.accent_color.disabled_theme": "(Tema etkinken devre dışı)",

--- a/src/services/launcher-config-service.ts
+++ b/src/services/launcher-config-service.ts
@@ -177,5 +177,8 @@ export async function completeOnboarding(): Promise<LauncherConfig> {
 }
 
 export async function resetOnboarding(): Promise<LauncherConfig> {
-  return setOnboardingCompletedVersion(null);
+  // Replay from Settings should be a local UI action. Persisting `null` here can
+  // make onboarding auto-open again on next launch if the app exits before the
+  // replay is completed.
+  return getLauncherConfig();
 }

--- a/src/services/launcher-config-service.ts
+++ b/src/services/launcher-config-service.ts
@@ -1,6 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { LauncherConfig, MemorySettings } from "../types/launcherConfig";
 
+export const ONBOARDING_VERSION = "launcher-onboarding-v1";
+
 /**
  * Fetches the current launcher configuration from the backend.
  * @returns A promise that resolves with the LauncherConfig.
@@ -153,4 +155,27 @@ export async function setGlobalCustomJvmArgs(jvmArgs: string | null): Promise<vo
     console.error("[LauncherConfigService] Failed to set global custom JVM args:", error);
     throw error;
   }
+}
+
+export async function setOnboardingCompletedVersion(
+  version: string | null,
+): Promise<LauncherConfig> {
+  console.log(
+    "[LauncherConfigService] Setting onboarding completed version:",
+    version,
+  );
+
+  const currentConfig = await getLauncherConfig();
+  return setLauncherConfig({
+    ...currentConfig,
+    onboarding_completed_version: version,
+  });
+}
+
+export async function completeOnboarding(): Promise<LauncherConfig> {
+  return setOnboardingCompletedVersion(ONBOARDING_VERSION);
+}
+
+export async function resetOnboarding(): Promise<LauncherConfig> {
+  return setOnboardingCompletedVersion(null);
 }

--- a/src/types/launcherConfig.ts
+++ b/src/types/launcherConfig.ts
@@ -45,6 +45,7 @@ export interface LauncherConfig {
   referral_state: ReferralState | null; // Referral tracking state
   last_played_profile: string | null; // Option<Uuid>
   pack_rollout_override: "auto" | "off" | "on";
+  onboarding_completed_version: string | null; // Option<String>
 }
 
 export interface ReferralInfo {


### PR DESCRIPTION
## Summary

NoRiskClient/issues#2727.

* Adds an interactive launcher onboarding tour modal (`OnboardingModal.tsx`) using Framer Motion and custom icons.
* Stores the completed version of the onboarding tour in launcher configuration to show it automatically on first launch (once terms are accepted).
* Adds a settings section in the settings tab to allow resetting the onboarding state and replaying the tour.
* Integrates translations across all supported languages (de, en, es, fr, hi, it, pl, pt, ru, tr). [TODO: Translations show english fallback]