### PR TITLE
fix(logs): Improve log window performance by removing antipatterrns

### DIFF
--- a/src/components/log/InstanceSidebar.tsx
+++ b/src/components/log/InstanceSidebar.tsx
@@ -263,14 +263,24 @@ export function InstanceSidebar({
   // Track processes user has requested to stop - show START immediately
   const [stoppingProcessIds, setStoppingProcessIds] = useState<Set<string>>(new Set());
 
-  // Get processes from store
-  const { processes, stoppedProcesses, processEndTimes, metrics, fetchProcesses, stopProcess, isLoading } = useProcessStore();
+  // Individual selectors avoid re-rendering on unrelated store churn, like the per-line `logs` map or cursor updates.
+  const processes = useProcessStore((state) => state.processes);
+  const stoppedProcesses = useProcessStore((state) => state.stoppedProcesses);
+  const processEndTimes = useProcessStore((state) => state.processEndTimes);
+  const metrics = useProcessStore((state) => state.metrics);
+  const fetchProcesses = useProcessStore((state) => state.fetchProcesses);
+  const stopProcess = useProcessStore((state) => state.stopProcess);
+  const isLoading = useProcessStore((state) => state.isLoading);
 
-  // Get launch state store for launch feedback
-  const { getProfileState, initiateButtonLaunch, finalizeButtonLaunch } = useLaunchStateStore();
+  // Individual selectors - a bare destructure re-renders this sidebar on any profile's launch status change, not just these instances.
+  const getProfileState = useLaunchStateStore((s) => s.getProfileState);
+  const initiateButtonLaunch = useLaunchStateStore((s) => s.initiateButtonLaunch);
+  const finalizeButtonLaunch = useLaunchStateStore((s) => s.finalizeButtonLaunch);
 
   // Get launcher log functions
-  const { addLauncherLog, clearLauncherLogs, clearLogs } = useProcessStore();
+  const addLauncherLog = useProcessStore((state) => state.addLauncherLog);
+  const clearLauncherLogs = useProcessStore((state) => state.clearLauncherLogs);
+  const clearLogs = useProcessStore((state) => state.clearLogs);
 
   // Fetch processes on mount
   useEffect(() => {

--- a/src/components/log/LogViewerCore.tsx
+++ b/src/components/log/LogViewerCore.tsx
@@ -130,7 +130,8 @@ export function LogViewerCore({
 }: LogViewerCoreProps) {
   const { t } = useTranslation();
   const accentColor = useThemeStore((state) => state.accentColor);
-  const { showThreadPrefix, toggleShowThreadPrefix } = useLogSettingsStore();
+  const showThreadPrefix = useLogSettingsStore((state) => state.showThreadPrefix);
+  const toggleShowThreadPrefix = useLogSettingsStore((state) => state.toggleShowThreadPrefix);
   const [searchTerm, setSearchTerm] = useState("");
   const deferredSearchTerm = useDeferredValue(searchTerm);
   const [levelFilters, setLevelFilters] = useState<Record<LogLevel, boolean>>({

--- a/src/components/log/MinecraftLogWindow.tsx
+++ b/src/components/log/MinecraftLogWindow.tsx
@@ -23,15 +23,14 @@ export function MinecraftLogWindow({ crashedProcess }: MinecraftLogWindowProps) 
   const { processes } = useProcessEvents({ autoFetch: true });
   const { logs: rawLogs } = useProcessLogs(selectedInstanceId);
 
-  const {
-    stoppedProcesses,
-    launcherLogs: launcherLogsMap,
-    selectedProcessId,
-    selectProcess,
-    clearLogs,
-    clearLauncherLogs,
-    markProcessStopped,
-  } = useProcessStore();
+  // Individual selectors - a bare destructure re-renders this window (and its search input) on every log line and metrics tick.
+  const stoppedProcesses = useProcessStore((state) => state.stoppedProcesses);
+  const launcherLogsMap = useProcessStore((state) => state.launcherLogs);
+  const selectedProcessId = useProcessStore((state) => state.selectedProcessId);
+  const selectProcess = useProcessStore((state) => state.selectProcess);
+  const clearLogs = useProcessStore((state) => state.clearLogs);
+  const clearLauncherLogs = useProcessStore((state) => state.clearLauncherLogs);
+  const markProcessStopped = useProcessStore((state) => state.markProcessStopped);
 
   const crashedProcessHandledRef = useRef(false);
   useEffect(() => {

--- a/src/components/log/SingleLogViewer.tsx
+++ b/src/components/log/SingleLogViewer.tsx
@@ -1,12 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useThemeStore } from "../../store/useThemeStore";
 import { useFontStore } from "../../store/font-store";
-import { useProcessStore } from "../../store/useProcessStore";
+import { useProcessStore, LogEntry } from "../../store/useProcessStore";
 import { LogViewerCore } from "./LogViewerCore";
 import { LogWindowTitlebar } from "./LogWindowTitlebar";
 import { getProcess } from "../../services/process-service";
 import { useProcessLogCursor } from "../../hooks/useProcessLogCursor";
+
+// Stable reference so the selectors below don't return a new array whenever some other process's logs update.
+const EMPTY_LOGS: LogEntry[] = [];
 
 interface SingleLogViewerProps {
   instanceId?: string;
@@ -20,8 +23,13 @@ export function SingleLogViewer({ instanceId, instanceName, profileId, accountNa
   const { t } = useTranslation();
   const accentColor = useThemeStore((state) => state.accentColor);
 
-  const logsMap = useProcessStore((state) => state.logs);
-  const launcherLogsMap = useProcessStore((state) => state.launcherLogs);
+  // Scoped to this instance/profile - selecting the whole map would re-render on every other running instance's log lines too.
+  const mcLogs = useProcessStore((state) =>
+    instanceId ? state.logs.get(instanceId) ?? EMPTY_LOGS : EMPTY_LOGS,
+  );
+  const launcherLogs = useProcessStore((state) =>
+    profileId ? state.launcherLogs.get(profileId) ?? EMPTY_LOGS : EMPTY_LOGS,
+  );
   const clearLogs = useProcessStore((state) => state.clearLogs);
   const clearLauncherLogs = useProcessStore((state) => state.clearLauncherLogs);
 
@@ -43,13 +51,6 @@ export function SingleLogViewer({ instanceId, instanceName, profileId, accountNa
   }, [instanceId]);
 
   useProcessLogCursor(sessionId, instanceId);
-
-  const mcLogs = instanceId ? (logsMap.get(instanceId) || []) : [];
-
-  const launcherLogs = useMemo(() => {
-    if (!profileId) return [];
-    return launcherLogsMap.get(profileId) || [];
-  }, [profileId, launcherLogsMap]);
 
   const logs = mcLogs.length > 0 ? mcLogs : launcherLogs;
 

--- a/src/hooks/useProcessEvents.ts
+++ b/src/hooks/useProcessEvents.ts
@@ -1,9 +1,12 @@
 import { useEffect, useRef } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { useProcessStore, ProcessMetrics } from "../store/useProcessStore";
+import { useProcessStore, ProcessMetrics, LogEntry } from "../store/useProcessStore";
 import i18n from '../i18n/i18n';
 import { EventType, ProcessMetricsPayload, MinecraftProcessExitedPayload } from "../types/events";
 import { ProcessState } from "../types/processState";
+
+// Stable reference so the useProcessLogs selector below doesn't return a new array on unrelated store field changes.
+const EMPTY_LOGS: LogEntry[] = [];
 
 // Launch status events that should be logged
 const LAUNCH_STATUS_EVENTS = new Set([
@@ -48,16 +51,13 @@ export function useProcessEvents(options: {
 } = {}) {
   const { autoFetch = true, processFilter } = options;
 
-  const {
-    fetchProcesses,
-    updateMetrics,
-    markProcessStopped,
-    addLauncherLog,
-    clearLauncherLogs,
-    clearLogs,
-    processes,
-    stoppedProcesses,
-  } = useProcessStore();
+  // Individual selectors - a bare destructure subscribes to every field, including the high-churn `logs` and `metrics` maps.
+  const fetchProcesses = useProcessStore((state) => state.fetchProcesses);
+  const updateMetrics = useProcessStore((state) => state.updateMetrics);
+  const markProcessStopped = useProcessStore((state) => state.markProcessStopped);
+  const addLauncherLog = useProcessStore((state) => state.addLauncherLog);
+  const clearLauncherLogs = useProcessStore((state) => state.clearLauncherLogs);
+  const clearLogs = useProcessStore((state) => state.clearLogs);
 
   const stateEventListenerRef = useRef<UnlistenFn | null>(null);
   // Track which profiles have started a new launch (to clear old MC logs)
@@ -195,8 +195,8 @@ export function useProcessEvents(options: {
     };
   }, [autoFetch, processFilter, fetchProcesses, updateMetrics, markProcessStopped, addLauncherLog, clearLauncherLogs, clearLogs]);
 
-  // Return store state and actions for convenience
-  return useProcessStore();
+  // Only select what callers actually use, rather than the entire store.
+  return { processes: useProcessStore((state) => state.processes) };
 }
 
 /**
@@ -204,10 +204,9 @@ export function useProcessEvents(options: {
  * NOTE: This hook only READS from the store. Use useProcessEvents to subscribe to log events.
  */
 export function useProcessLogs(processId: string | null) {
-  const { getLogsForProcess, logs } = useProcessStore();
+  const logs = useProcessStore((state) =>
+    processId ? state.logs.get(processId) ?? EMPTY_LOGS : EMPTY_LOGS,
+  );
 
-  return {
-    logs: processId ? getLogsForProcess(processId) : [],
-    allLogs: logs,
-  };
+  return { logs };
 }


### PR DESCRIPTION
That's the best way I know to avoid the constant re-rendering, is there something better?